### PR TITLE
[Feat] 엔티티 초기 설계 - 사용자 중심 도메인 그룹

### DIFF
--- a/src/main/java/com/seohaeng/backend/notification/entity/Notification.java
+++ b/src/main/java/com/seohaeng/backend/notification/entity/Notification.java
@@ -1,0 +1,26 @@
+package com.seohaeng.backend.notification.entity;
+
+import com.seohaeng.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String preview;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/com/seohaeng/backend/place/entity/Place.java
+++ b/src/main/java/com/seohaeng/backend/place/entity/Place.java
@@ -1,0 +1,24 @@
+package com.seohaeng.backend.place.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Place {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String address;
+
+    private String introduction;
+
+    private String websiteUrl;
+
+}

--- a/src/main/java/com/seohaeng/backend/placeEvent/entity/PlaceEvent.java
+++ b/src/main/java/com/seohaeng/backend/placeEvent/entity/PlaceEvent.java
@@ -1,0 +1,28 @@
+package com.seohaeng.backend.placeEvent.entity;
+
+import com.seohaeng.backend.place.entity.Place;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class PlaceEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    private String description;
+
+    private String rewardDescription;
+
+    private String rewardImageUrl;
+
+    private String ownerMessage;
+
+}

--- a/src/main/java/com/seohaeng/backend/readingSpot/entity/ReadingSpot.java
+++ b/src/main/java/com/seohaeng/backend/readingSpot/entity/ReadingSpot.java
@@ -1,0 +1,36 @@
+package com.seohaeng.backend.readingSpot.entity;
+
+import com.seohaeng.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ReadingSpot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private String imageUrl;
+
+    private String content;
+
+    private int likes;
+
+    private String bookTitle;
+
+    private String bookAuthor;
+
+    private LocalDateTime bookPubDate;
+
+    private String bookImageUrl;
+
+}

--- a/src/main/java/com/seohaeng/backend/readingSpotComment/entity/ReadingSpotComment.java
+++ b/src/main/java/com/seohaeng/backend/readingSpotComment/entity/ReadingSpotComment.java
@@ -1,0 +1,28 @@
+package com.seohaeng.backend.readingSpotComment.entity;
+
+import com.seohaeng.backend.readingSpot.entity.ReadingSpot;
+import com.seohaeng.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ReadingSpotComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reading_spot_id", nullable = false)
+    private ReadingSpot readingSpot;
+
+    @Column(nullable = false)
+    private String content;
+
+}

--- a/src/main/java/com/seohaeng/backend/review/entity/Review.java
+++ b/src/main/java/com/seohaeng/backend/review/entity/Review.java
@@ -1,0 +1,33 @@
+package com.seohaeng.backend.review.entity;
+
+import com.seohaeng.backend.place.entity.Place;
+import com.seohaeng.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private Integer rating;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+}

--- a/src/main/java/com/seohaeng/backend/savedPlace/entity/SavedPlace.java
+++ b/src/main/java/com/seohaeng/backend/savedPlace/entity/SavedPlace.java
@@ -1,0 +1,24 @@
+package com.seohaeng.backend.savedPlace.entity;
+import com.seohaeng.backend.user.entity.User;
+import com.seohaeng.backend.place.entity.Place;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class SavedPlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+}

--- a/src/main/java/com/seohaeng/backend/user/entity/LoginInfo.java
+++ b/src/main/java/com/seohaeng/backend/user/entity/LoginInfo.java
@@ -1,0 +1,22 @@
+package com.seohaeng.backend.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class LoginInfo {
+    @Id @GeneratedValue
+    private Long id;
+
+    private String provider;
+
+    @Column(nullable = false)
+    private String email;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+}

--- a/src/main/java/com/seohaeng/backend/user/entity/User.java
+++ b/src/main/java/com/seohaeng/backend/user/entity/User.java
@@ -1,0 +1,22 @@
+package com.seohaeng.backend.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class User {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private String imageUrl;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private LoginInfo loginInfo;
+
+}


### PR DESCRIPTION
## 📌 작업 내용

> 사용자 중심 도메인 그룹 엔티티 초기 설계

## ✨ 참고 사항

> 생성일, 시간 정보 필드는 `BaseEntity` 추가 후 적용하겠습니다.


## 🧩 연관 이슈

> close #1 


<br>