### PR TITLE
[Feat] 책 검색, 북챌린지 이벤트 서점 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
 
 	// S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// WebClient 사용을 위한 WebFlux 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProof.java
+++ b/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProof.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.bookChallenge.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.place.entity.Place;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProofComment.java
+++ b/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProofComment.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.bookChallenge.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProofImage.java
+++ b/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProofImage.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.bookChallenge.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProofLike.java
+++ b/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProofLike.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.bookChallenge.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/seohaeng/backend/domain/bookChallenge/service/BookChallengeCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/bookChallenge/service/BookChallengeCommandService.java
@@ -12,7 +12,7 @@ import com.seohaeng.backend.domain.bookChallenge.repository.BookChallengeProofIm
 import com.seohaeng.backend.domain.bookChallenge.repository.BookChallengeProofLikeRepository;
 import com.seohaeng.backend.domain.bookChallenge.repository.BookChallengeProofRepository;
 import com.seohaeng.backend.domain.place.entity.Place;
-import com.seohaeng.backend.domain.place.entity.repository.PlaceRepository;
+import com.seohaeng.backend.domain.place.repository.PlaceRepository;
 import com.seohaeng.backend.domain.user.entity.User;
 import com.seohaeng.backend.domain.user.repository.UserRepository;
 import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;

--- a/src/main/java/com/seohaeng/backend/domain/common/controller/CommonController.java
+++ b/src/main/java/com/seohaeng/backend/domain/common/controller/CommonController.java
@@ -1,0 +1,41 @@
+package com.seohaeng.backend.domain.common.controller;
+
+import com.seohaeng.backend.domain.common.dto.CommonResponseDTO;
+import com.seohaeng.backend.domain.common.service.CommonQueryService;
+import com.seohaeng.backend.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/common")
+@RequiredArgsConstructor
+public class CommonController {
+
+    private final CommonQueryService commonQueryService;
+
+    @Operation(
+            summary = "책 검색 API",
+            description = """
+        네이버 책 검색 API를 중계하는 엔드포인트 입니다.
+        Parameter:
+        - `query`: 검색어
+        - `display`: 한 번에 표시할 검색 결과 개수(기본값: 10, 최댓값: 100)
+        - `start`: 검색 시작 위치(기본값: 1, 최댓값: 1000)
+        - `sort`: 검색 결과 정렬 방법 ( sim: 정확도순으로 내림차순 정렬(기본값) / date: 출간일순으로 내림차순 정렬)
+    """)
+    @GetMapping("/books")
+    public ApiResponse<CommonResponseDTO.bookSearchResultListDTO> searchBooks (@RequestParam @NotBlank String query,
+                                                                               @RequestParam(required = false)  @Min(1) @Max(100) Integer display,
+                                                                               @RequestParam(required = false)  @Min(1) @Max(1000) Integer start,
+                                                                               @RequestParam(required = false)  @Pattern(regexp = "sim|date") String sort){
+        CommonResponseDTO.bookSearchResultListDTO result = commonQueryService.bookSearch(query, display, start, sort);
+        return ApiResponse.onSuccess(result);
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/common/converter/CommonConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/common/converter/CommonConverter.java
@@ -1,0 +1,24 @@
+package com.seohaeng.backend.domain.common.converter;
+
+import com.seohaeng.backend.domain.common.dto.BookSearchResponseDTO;
+import com.seohaeng.backend.domain.common.dto.CommonResponseDTO;
+
+import java.util.List;
+
+public class CommonConverter {
+
+    public static CommonResponseDTO.bookSearchResultDTO toCommonResponseDTO(BookSearchResponseDTO.BookItemDTO bookItem){
+        return CommonResponseDTO.bookSearchResultDTO.builder()
+                .title(bookItem.getTitle())
+                .author(bookItem.getAuthor())
+                .bookImage(bookItem.getImage())
+                .build();
+    }
+
+    public static CommonResponseDTO.bookSearchResultListDTO tobookSearchResultListDTO(
+            List<CommonResponseDTO.bookSearchResultDTO> bookSearchResultDTOList){
+        return CommonResponseDTO.bookSearchResultListDTO.builder()
+                .bookSearchResults(bookSearchResultDTOList)
+                .build();
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/common/dto/BookSearchResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/common/dto/BookSearchResponseDTO.java
@@ -1,0 +1,33 @@
+package com.seohaeng.backend.domain.common.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class BookSearchResponseDTO {
+
+    @NoArgsConstructor
+    @Getter
+    public static class SearchResponseDTO {
+        private String lastBuildDate;
+        private int total;
+        private int start;
+        private int display;
+        private List<BookItemDTO> items;
+    }
+
+    @NoArgsConstructor
+    @Getter
+    public static class BookItemDTO {
+        private String title;
+        private String link;
+        private String image;
+        private String author;
+        private String price;
+        private String discount;
+        private String publisher;
+        private String pubdate;
+        private String isbn;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/common/dto/CommonResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/common/dto/CommonResponseDTO.java
@@ -1,0 +1,26 @@
+package com.seohaeng.backend.domain.common.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+public class CommonResponseDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class bookSearchResultDTO {
+        private String title;
+        private String author;
+        private String bookImage;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class bookSearchResultListDTO {
+        private List<bookSearchResultDTO> bookSearchResults;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/seohaeng/backend/domain/common/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.seohaeng.backend.domain.common;
+package com.seohaeng.backend.domain.common.entity;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;

--- a/src/main/java/com/seohaeng/backend/domain/common/service/CommonCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/common/service/CommonCommandService.java
@@ -1,0 +1,4 @@
+package com.seohaeng.backend.domain.common.service;
+
+public class CommonCommandService {
+}

--- a/src/main/java/com/seohaeng/backend/domain/common/service/CommonQueryService.java
+++ b/src/main/java/com/seohaeng/backend/domain/common/service/CommonQueryService.java
@@ -1,0 +1,67 @@
+package com.seohaeng.backend.domain.common.service;
+
+import com.seohaeng.backend.domain.common.converter.CommonConverter;
+import com.seohaeng.backend.domain.common.dto.BookSearchResponseDTO;
+import com.seohaeng.backend.domain.common.dto.CommonResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommonQueryService {
+
+    @Value("${NAVER_CLIENT_ID}")
+    private String NaverClientId;
+
+    @Value("${NAVER_CLIENT_SECRET}")
+    private String NaverClientSecret;
+
+    private final String NAVER_API_URL = "https://openapi.naver.com/v1/search/book.json";
+
+    private final RestTemplate restTemplate;
+
+    public CommonResponseDTO.bookSearchResultListDTO bookSearch (
+            String query,
+            Integer display,
+            Integer start,
+            String sort){
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://openapi.naver.com")
+                .defaultHeader("X-Naver-Client-Id", NaverClientId)
+                .defaultHeader("X-Naver-Client-Secret", NaverClientSecret)
+                .build();
+
+        BookSearchResponseDTO.SearchResponseDTO responseJson = webClient.get()
+                .uri(uriBuilder -> {
+                    UriBuilder builder = uriBuilder
+                            .path("/v1/search/book.json")
+                            .queryParam("query", query);
+
+                    if (display != null) builder.queryParam("display", display);
+                    if (start != null) builder.queryParam("start", start);
+                    if (sort != null) builder.queryParam("sort", sort);
+                    return builder.build();
+                })
+                .retrieve()
+                .bodyToMono(BookSearchResponseDTO.SearchResponseDTO.class)
+                .block();
+
+        List<BookSearchResponseDTO.BookItemDTO> BookItemDTOList = responseJson.getItems();
+
+        List<CommonResponseDTO.bookSearchResultDTO> bookSearchResults  = BookItemDTOList.stream()
+                .map(CommonConverter::toCommonResponseDTO)
+                .collect(Collectors.toList());
+
+        return CommonConverter.tobookSearchResultListDTO(bookSearchResults );
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/seohaeng/backend/domain/notification/entity/Notification.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.notification.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/seohaeng/backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/controller/PlaceController.java
@@ -1,0 +1,40 @@
+package com.seohaeng.backend.domain.place.controller;
+
+import com.seohaeng.backend.domain.place.dto.PlaceResponseDTO;
+import com.seohaeng.backend.domain.place.service.PlaceQueryService;
+import com.seohaeng.backend.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/places")
+public class PlaceController {
+
+    private final PlaceQueryService placeQueryService;
+
+    @Operation(
+            summary = "북챌린지 서점 조회 API",
+            description = """
+        북챌린지 이벤트가 진행 중인 서점들의 목록을 페이징 처리하여 조회합니다.
+        Parameter:
+        - `page`: 페이지 번호 (1부터 시작)
+        - `size`: 한 페이지당 게시글 개수 (기본값: 10)
+    """
+    )
+    @GetMapping("/book-challenges")
+    public ApiResponse<PlaceResponseDTO.placeListDto> getBookChallengePlaces(
+            @RequestParam(name = "page", defaultValue = "1") @Min(1)Integer page,
+            @RequestParam(name = "size", defaultValue = "10") @Min(1)Integer size
+    ) {
+        return ApiResponse.onSuccess(placeQueryService.findBookChallengePlaces(page,size));
+    }
+
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/converter/PlaceConverter.java
@@ -1,0 +1,35 @@
+package com.seohaeng.backend.domain.place.converter;
+
+import com.seohaeng.backend.domain.place.dto.PlaceResponseDTO;
+import com.seohaeng.backend.domain.place.entity.Place;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public class PlaceConverter {
+
+    public static PlaceResponseDTO.placeDto toplaceDto (Place place) {
+     return PlaceResponseDTO.placeDto.builder()
+             .id(place.getId())
+             .name(place.getName())
+             .placeType(place.getPlaceType())
+             .introduction(place.getIntroduction())
+             .address(place.getAddress())
+             .websiteUrl(place.getWebsiteUrl())
+             .latitude(place.getLatitude())
+             .longitude(place.getLongitude())
+             .build();
+    }
+
+    public static PlaceResponseDTO.placeListDto toplaceListDto (Page<Place> placePage,
+                                                                List<PlaceResponseDTO.placeDto> placeDtoList) {
+        return PlaceResponseDTO.placeListDto.builder()
+                .listSize(placeDtoList.size())
+                .totalPage(placePage.getTotalPages())
+                .totalElements(placePage.getTotalElements())
+                .isFirst(placePage.isFirst())
+                .isLast(placePage.isLast())
+                .placeList(placeDtoList)
+                .build();
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/dto/PlaceResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/dto/PlaceResponseDTO.java
@@ -1,0 +1,39 @@
+package com.seohaeng.backend.domain.place.dto;
+
+import com.seohaeng.backend.domain.place.entity.PlaceType;
+import lombok.*;
+
+import java.util.List;
+
+public class PlaceResponseDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class placeDto{
+        private Long id;
+        private String name;
+        private PlaceType placeType;
+        private String address;
+        private String introduction;
+        private String websiteUrl;
+        private Double latitude;
+        private Double longitude;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class placeListDto{
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+        private List<placeDto> placeList;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/Place.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/Place.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.place.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/Place.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/Place.java
@@ -3,10 +3,14 @@ package com.seohaeng.backend.domain.place.entity;
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Getter
 public class Place extends BaseEntity {
 
     @Id
@@ -16,11 +20,22 @@ public class Place extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    private LocalTime openingTime;
+
+    private LocalTime closingTime;
+
     private String address;
 
     private String introduction;
 
     private String websiteUrl;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    @Enumerated(EnumType.STRING)
+    private PlaceType placeType;
 
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
     private boolean bookChallengeStatus = false;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/PlaceEvent.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/PlaceEvent.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.place.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/PlaceType.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/PlaceType.java
@@ -1,0 +1,8 @@
+package com.seohaeng.backend.domain.place.entity;
+
+public enum PlaceType {
+    INDEPENDENT_BOOKSTORE,
+    BOOK_CAFE,
+    BOOK_STAY,
+    SPACE_BOOKMARK;
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/Review.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/Review.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.place.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/SavedPlace.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/SavedPlace.java
@@ -1,5 +1,5 @@
 package com.seohaeng.backend.domain.place.entity;
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/repository/PlaceRepository.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/repository/PlaceRepository.java
@@ -1,7 +1,0 @@
-package com.seohaeng.backend.domain.place.entity.repository;
-
-import com.seohaeng.backend.domain.place.entity.Place;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PlaceRepository extends JpaRepository<Place, Long> {
-}

--- a/src/main/java/com/seohaeng/backend/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/repository/PlaceRepository.java
@@ -1,0 +1,10 @@
+package com.seohaeng.backend.domain.place.repository;
+
+import com.seohaeng.backend.domain.place.entity.Place;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+    Page<Place> findAllByBookChallengeStatusTrue(Pageable pageable);
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/service/PlaceQueryService.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/service/PlaceQueryService.java
@@ -1,0 +1,32 @@
+package com.seohaeng.backend.domain.place.service;
+
+import com.seohaeng.backend.domain.place.converter.PlaceConverter;
+import com.seohaeng.backend.domain.place.dto.PlaceResponseDTO;
+import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaceQueryService {
+
+    private final PlaceRepository placeRepository;
+
+    public PlaceResponseDTO.placeListDto findBookChallengePlaces(Integer page, Integer size) {
+
+        PageRequest pageRequest = PageRequest.of(page-1, size);
+        Page<Place> bookChallengePlaces = placeRepository.findAllByBookChallengeStatusTrue(pageRequest);
+        List<PlaceResponseDTO.placeDto> placeDtoList = bookChallengePlaces.getContent().stream()
+                .map(PlaceConverter::toplaceDto).collect(Collectors.toList());
+
+        return PlaceConverter.toplaceListDto(bookChallengePlaces, placeDtoList);
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/readingSpot/entity/ReadingSpot.java
+++ b/src/main/java/com/seohaeng/backend/domain/readingSpot/entity/ReadingSpot.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.readingSpot.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/seohaeng/backend/domain/readingSpot/entity/ReadingSpotComment.java
+++ b/src/main/java/com/seohaeng/backend/domain/readingSpot/entity/ReadingSpotComment.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.readingSpot.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/seohaeng/backend/domain/travelCourse/entity/Stamp.java
+++ b/src/main/java/com/seohaeng/backend/domain/travelCourse/entity/Stamp.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.travelCourse.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/seohaeng/backend/domain/travelCourse/entity/TravelCourse.java
+++ b/src/main/java/com/seohaeng/backend/domain/travelCourse/entity/TravelCourse.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.travelCourse.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/seohaeng/backend/domain/travelCourse/entity/TravelCourseSchedule.java
+++ b/src/main/java/com/seohaeng/backend/domain/travelCourse/entity/TravelCourseSchedule.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.travelCourse.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/seohaeng/backend/domain/user/entity/LoginInfo.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/entity/LoginInfo.java
@@ -1,8 +1,7 @@
 package com.seohaeng.backend.domain.user.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Entity

--- a/src/main/java/com/seohaeng/backend/domain/user/entity/User.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.user.entity;
 
-import com.seohaeng.backend.domain.common.BaseEntity;
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.travelCourse.entity.Stamp;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/seohaeng/backend/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/seohaeng/backend/global/apiPayload/exception/ExceptionAdvice.java
@@ -27,15 +27,14 @@ import java.util.Optional;
 @RestControllerAdvice(annotations = RestController.class)
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
-
     @ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
-        String errorMessage = e.getConstraintViolations().stream()
-                .map(constraintViolation -> constraintViolation.getMessage())
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
-
-        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+        return handleExceptionInternalConstraint(
+                e,
+                ErrorStatus._BAD_REQUEST,
+                HttpHeaders.EMPTY,
+                request
+        );
     }
 
     @Override

--- a/src/main/java/com/seohaeng/backend/global/configuration/RestTemplateConfig.java
+++ b/src/main/java/com/seohaeng/backend/global/configuration/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.seohaeng.backend.global.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,7 @@ cloud:
     credentials:
       accessKey: ${AWS_ACCESS_KEY_ID}
       secretKey: ${AWS_SECRET_ACCESS_KEY}
+  naver:
+    api:
+      client-id: ${NAVER_CLIENT_ID}
+      client-secret: ${NAVER_CLIENT_SECRET}


### PR DESCRIPTION
## 📌 작업 내용

> ### 1. 책 검색 API 구현
> - **네이버 책 검색 API**를 중계하는 엔드포인트를 구현했습니다. 북챌린지 인증 등록, 공간책갈피 등록에 사용됩니다.
> - 클라이언트에서 검색어(query)를 전달받아 네이버 오픈 API에 요청을 보내고, 받은 응답을 가공하여 반환합니다.
> - 페이지네이션(display, start)과 정렬(sort) 파라미터를 지원합니다.
>- 관련 환경변수는 노션 페이지를 참고해주세요.

> ### 2. 북챌린지 이벤트 서점 조회 API 구현
> - 북챌린지 이벤트가 진행중인 서점 목록을 조회하는 API를 구현했습니다.
> - bookChallengeStatus가 true인 서점 목록을 반환합니다.

> ### 3.Place 엔티티 필드 변경
> - Place 엔티티에 latitude, longitude, placeType, openingTime, closingTime 필드가 추가되었습니다.
> -  **시설의 유형 구분을 위해 placeType enum 클래스가 추가되었습니다.** Place 엔티티의 필드로 사용됩니다.
```
public enum PlaceType {
    INDEPENDENT_BOOKSTORE, // 독립서점
    BOOK_CAFE, // 북카페
    BOOK_STAY, // 북스테이
    SPACE_BOOKMARK; // 공간책갈피
}
```
## ✨ 참고 사항

> 관련 환경변수는 노션 페이지를 참고해주세요.

## 🧩 연관 이슈

> close #10


<br>