### PR TITLE
[Refactor] Place 도메인 엔티티 수정, 리뷰 관련 API구현

### DIFF
--- a/src/main/java/com/seohaeng/backend/domain/bookChallenge/converter/BookChallengeConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/bookChallenge/converter/BookChallengeConverter.java
@@ -4,7 +4,7 @@ import com.seohaeng.backend.domain.bookChallenge.dto.BookChallengeRequestDTO;
 import com.seohaeng.backend.domain.bookChallenge.dto.BookChallengeResponseDTO;
 import com.seohaeng.backend.domain.bookChallenge.entity.BookChallengeProof;
 import com.seohaeng.backend.domain.bookChallenge.entity.BookChallengeProofComment;
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProof.java
+++ b/src/main/java/com/seohaeng/backend/domain/bookChallenge/entity/BookChallengeProof.java
@@ -1,7 +1,7 @@
 package com.seohaeng.backend.domain.bookChallenge.entity;
 
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/seohaeng/backend/domain/bookChallenge/service/BookChallengeCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/bookChallenge/service/BookChallengeCommandService.java
@@ -11,7 +11,7 @@ import com.seohaeng.backend.domain.bookChallenge.repository.BookChallengeProofCo
 import com.seohaeng.backend.domain.bookChallenge.repository.BookChallengeProofImageRepository;
 import com.seohaeng.backend.domain.bookChallenge.repository.BookChallengeProofLikeRepository;
 import com.seohaeng.backend.domain.bookChallenge.repository.BookChallengeProofRepository;
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.place.repository.PlaceRepository;
 import com.seohaeng.backend.domain.user.entity.User;
 import com.seohaeng.backend.domain.user.repository.UserRepository;

--- a/src/main/java/com/seohaeng/backend/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/converter/PlaceConverter.java
@@ -1,7 +1,7 @@
 package com.seohaeng.backend.domain.place.converter;
 
 import com.seohaeng.backend.domain.place.dto.PlaceResponseDTO;
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -17,6 +17,7 @@ public class PlaceConverter {
              .address(place.getAddress())
              .websiteUrl(place.getWebsiteUrl())
              .latitude(place.getLatitude())
+             .description(place.getDescription())
              .longitude(place.getLongitude())
              .build();
     }

--- a/src/main/java/com/seohaeng/backend/domain/place/dto/PlaceResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/dto/PlaceResponseDTO.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.place.dto;
 
-import com.seohaeng.backend.domain.place.entity.PlaceType;
+import com.seohaeng.backend.domain.place.entity.enums.PlaceType;
 import lombok.*;
 
 import java.util.List;
@@ -17,6 +17,7 @@ public class PlaceResponseDTO {
         private String name;
         private PlaceType placeType;
         private String address;
+        private String description;
         private String introduction;
         private String websiteUrl;
         private Double latitude;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/PlaceType.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/PlaceType.java
@@ -1,8 +1,0 @@
-package com.seohaeng.backend.domain.place.entity;
-
-public enum PlaceType {
-    INDEPENDENT_BOOKSTORE,
-    BOOK_CAFE,
-    BOOK_STAY,
-    SPACE_BOOKMARK;
-}

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/enums/PlaceType.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/enums/PlaceType.java
@@ -1,0 +1,9 @@
+package com.seohaeng.backend.domain.place.entity.enums;
+
+public enum PlaceType {
+    BOOKSTORE, // 독립서점
+    TOURIST_SPOT, // 관광지
+    RESTAURANT, // 식당
+    FESTIVAL, // 축제
+    SPACE_BOOKMARK // 공간책갈피
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/place/BookStoreAttribute.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/place/BookStoreAttribute.java
@@ -1,0 +1,60 @@
+package com.seohaeng.backend.domain.place.entity.place;
+
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+public class BookStoreAttribute extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    // 북카페, 북스테이
+    private boolean bookCafe;
+    private boolean bookStay;
+    // 나중에 북챌린지 여부 이쪽으로 이동
+
+    // 북살롱
+    private boolean salonAll;
+    private boolean readingClub;
+    private boolean bookTalk;
+    private boolean lecture;
+    private boolean originalContent;
+    private boolean bookWellage;
+
+    // 편의 정보
+    private boolean convenienceAll;
+    private boolean spaceRental;
+    private boolean parking;
+    private boolean petFriendly;
+    private boolean bookStorage;
+    private boolean creatorSupport;
+    private boolean bookOrder;
+    private boolean bookDelivery;
+
+    // 컬렉션북
+    private boolean collectionAll;
+    private boolean indiePublication;
+    private boolean usedBooks;
+    private boolean goods;
+    private boolean artBook;
+    private boolean illustrationBook;
+    private boolean giftShop;
+    private boolean souvenirs;
+
+    // 테이스트
+    private boolean tasteAll;
+    private boolean pub;
+    private boolean cafe;
+    private boolean snack;
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/place/Place.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/place/Place.java
@@ -23,6 +23,8 @@ public class Place extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    private Long contentId;
+
     private String description;
 
     private LocalTime openingTime;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/place/Place.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/place/Place.java
@@ -1,12 +1,15 @@
-package com.seohaeng.backend.domain.place.entity;
+package com.seohaeng.backend.domain.place.entity.place;
 
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
+import com.seohaeng.backend.domain.place.entity.enums.PlaceType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -19,6 +22,8 @@ public class Place extends BaseEntity {
 
     @Column(nullable = false)
     private String name;
+
+    private String description;
 
     private LocalTime openingTime;
 
@@ -33,6 +38,12 @@ public class Place extends BaseEntity {
     private Double latitude;
 
     private Double longitude;
+
+    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<PlaceImage> placeImages = new ArrayList<>();
+
+    @OneToOne(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private BookStoreAttribute bookStoreAttribute; // placeType이 BOOKSTORE일때만 사용
 
     @Enumerated(EnumType.STRING)
     private PlaceType placeType;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/place/Place.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/place/Place.java
@@ -2,6 +2,7 @@ package com.seohaeng.backend.domain.place.entity.place;
 
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.place.entity.enums.PlaceType;
+import com.seohaeng.backend.domain.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/place/PlaceEvent.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/place/PlaceEvent.java
@@ -1,24 +1,27 @@
-package com.seohaeng.backend.domain.place.entity;
+package com.seohaeng.backend.domain.place.entity.place;
+
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
-import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class SavedPlace extends BaseEntity {
+public class PlaceEvent extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id", nullable = false)
     private Place place;
 
+    private String description;
+
+    private String rewardDescription;
+
+    private String rewardImageUrl;
+
+    private String ownerMessage;
 }

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/place/PlaceImage.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/place/PlaceImage.java
@@ -1,33 +1,23 @@
-package com.seohaeng.backend.domain.place.entity;
+package com.seohaeng.backend.domain.place.entity.place;
 
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
-import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Review extends BaseEntity {
+@Getter
+public class PlaceImage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private String content;
-
-    @Column(nullable = false)
-    private Integer rating;
-
     private String imageUrl;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id", nullable = false)
     private Place place;
-
 }

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/place/SavedPlace.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/place/SavedPlace.java
@@ -1,28 +1,24 @@
-package com.seohaeng.backend.domain.place.entity;
-
+package com.seohaeng.backend.domain.place.entity.place;
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
+import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class PlaceEvent extends BaseEntity {
+public class SavedPlace extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id", nullable = false)
     private Place place;
-
-    private String description;
-
-    private String rewardDescription;
-
-    private String rewardImageUrl;
-
-    private String ownerMessage;
 
 }

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/review/Review.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/review/Review.java
@@ -1,0 +1,39 @@
+package com.seohaeng.backend.domain.place.entity.review;
+
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
+import com.seohaeng.backend.domain.place.entity.place.Place;
+import com.seohaeng.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private Integer rating;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ReviewImage> reviewImageList = new ArrayList<>();
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/entity/review/ReviewImage.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/entity/review/ReviewImage.java
@@ -1,0 +1,23 @@
+package com.seohaeng.backend.domain.place.entity.review;
+
+import com.seohaeng.backend.domain.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+public class ReviewImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+}

--- a/src/main/java/com/seohaeng/backend/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/repository/PlaceRepository.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.place.repository;
 
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/seohaeng/backend/domain/place/service/PlaceQueryService.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/service/PlaceQueryService.java
@@ -2,7 +2,7 @@ package com.seohaeng.backend.domain.place.service;
 
 import com.seohaeng.backend.domain.place.converter.PlaceConverter;
 import com.seohaeng.backend.domain.place.dto.PlaceResponseDTO;
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/seohaeng/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/controller/ReviewController.java
@@ -1,0 +1,49 @@
+package com.seohaeng.backend.domain.review.controller;
+
+import com.seohaeng.backend.domain.review.dto.ReviewRequestDTO;
+import com.seohaeng.backend.domain.review.dto.ReviewResponseDTO;
+import com.seohaeng.backend.domain.review.service.ReviewCommandService;
+import com.seohaeng.backend.global.apiPayload.ApiResponse;
+import com.seohaeng.backend.global.apiPayload.code.status.SuccessStatus;
+import com.seohaeng.backend.global.security.handler.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewCommandService reviewCommandService;
+
+    @Operation(
+            summary = "리뷰 작성 API",
+            description = """
+    특정 장소에 대한 리뷰를 작성합니다.
+
+    - placeId를 통해 리뷰할 장소를 지정합니다.
+    - 텍스트 리뷰 내용은 request 필드로 전송되며, JSON 형식의 리뷰 정보가 포함되어야 합니다.
+    - 최대 10장의 리뷰 이미지를 함께 업로드할 수 있습니다.
+    """
+    )
+    @PostMapping(value = "/{placeId}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ReviewResponseDTO.CreateReviewResponseDTO> registerReview (
+            @AuthUser Long userId,
+            @PathVariable("placeId") Long placeId,
+            @RequestPart("request") @Valid ReviewRequestDTO.CreateReviewRequestDTO request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images){
+        if (images != null && images.size() > 10) {
+            throw new IllegalArgumentException("이미지는 최대 10장까지 업로드할 수 있습니다.");
+        }
+        ReviewResponseDTO.CreateReviewResponseDTO result = reviewCommandService.createReview(request, userId, placeId, images);
+        return ApiResponse.of(SuccessStatus.REVIEW_CREATE_SUCCESS, result);
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/controller/ReviewController.java
@@ -1,13 +1,16 @@
 package com.seohaeng.backend.domain.review.controller;
 
+import com.seohaeng.backend.domain.bookChallenge.dto.BookChallengeResponseDTO;
 import com.seohaeng.backend.domain.review.dto.ReviewRequestDTO;
 import com.seohaeng.backend.domain.review.dto.ReviewResponseDTO;
 import com.seohaeng.backend.domain.review.service.ReviewCommandService;
+import com.seohaeng.backend.domain.review.service.ReviewQueryService;
 import com.seohaeng.backend.global.apiPayload.ApiResponse;
 import com.seohaeng.backend.global.apiPayload.code.status.SuccessStatus;
 import com.seohaeng.backend.global.security.handler.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +26,7 @@ import java.util.List;
 public class ReviewController {
 
     private final ReviewCommandService reviewCommandService;
+    private final ReviewQueryService reviewQueryService;
 
     @Operation(
             summary = "리뷰 작성 API",
@@ -45,5 +49,21 @@ public class ReviewController {
         }
         ReviewResponseDTO.CreateReviewResponseDTO result = reviewCommandService.createReview(request, userId, placeId, images);
         return ApiResponse.of(SuccessStatus.REVIEW_CREATE_SUCCESS, result);
+    }
+
+    @Operation(
+            summary = "리뷰 목록 조회 API",
+            description = """
+    특정 장소에 대한 리뷰 목록을 조회합니다 API"
+    - placeId를 통해 리뷰 목록을 조회할 장소를 지정합니다.
+    """
+    )
+    @GetMapping(value = "/{placeId}")
+    public ApiResponse<ReviewResponseDTO.GetReviewListResponseDTO> getReviews(
+            @PathVariable("placeId") Long placeId,
+            @RequestParam(name = "page", defaultValue = "1") @Min(1)Integer page,
+            @RequestParam(name = "size", defaultValue = "20") @Min(1)Integer size
+    ){
+        return ApiResponse.onSuccess(reviewQueryService.getReviewList(page, size, placeId));
     }
 }

--- a/src/main/java/com/seohaeng/backend/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/converter/ReviewConverter.java
@@ -2,19 +2,47 @@ package com.seohaeng.backend.domain.review.converter;
 
 import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.review.dto.ReviewRequestDTO;
+import com.seohaeng.backend.domain.review.dto.ReviewResponseDTO;
 import com.seohaeng.backend.domain.review.entity.Review;
 import com.seohaeng.backend.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 public class ReviewConverter {
 
-    public static Review toReview(
-            ReviewRequestDTO.CreateReviewRequestDTO reviewRequestDTO, User user, Place place) {
+    public static Review toReview(ReviewRequestDTO.CreateReviewRequestDTO reviewRequestDTO, User user, Place place) {
         return Review.builder()
                 .place(place)
                 .content(reviewRequestDTO.getContent())
                 .rating(reviewRequestDTO.getRating())
                 .visitedDate(reviewRequestDTO.getVisitedDate())
                 .user(user)
+                .build();
+    }
+
+    public static ReviewResponseDTO.GetReviewResponseDTO toGetReviewResponseDTO(Review review, List<String> reviewImageList) {
+        return ReviewResponseDTO.GetReviewResponseDTO.builder()
+                .createdAt(review.getCreatedAt().toLocalDate())
+                .creatorId(review.getUser().getId())
+                .PlaceId(review.getPlace().getId())
+                .ReviewId(review.getId())
+                .rating(review.getRating())
+                .reviewContent(review.getContent())
+                .reviewImageList(reviewImageList)
+                .build();
+    }
+
+    public static ReviewResponseDTO.GetReviewListResponseDTO toGetReviewListResponseDTO(
+            Page<Review> reviewPage, List<ReviewResponseDTO.GetReviewResponseDTO> reviewResponseDTOS, Double totalRating) {
+        return ReviewResponseDTO.GetReviewListResponseDTO.builder()
+                .listSize(reviewPage.getSize())
+                .totalPage(reviewPage.getTotalPages())
+                .totalElements(reviewPage.getTotalElements())
+                .isFirst(reviewPage.isFirst())
+                .isLast(reviewPage.isLast())
+                .totalReviewRating(totalRating)
+                .getReviewList(reviewResponseDTOS)
                 .build();
     }
 }

--- a/src/main/java/com/seohaeng/backend/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/converter/ReviewConverter.java
@@ -1,0 +1,20 @@
+package com.seohaeng.backend.domain.review.converter;
+
+import com.seohaeng.backend.domain.place.entity.place.Place;
+import com.seohaeng.backend.domain.review.dto.ReviewRequestDTO;
+import com.seohaeng.backend.domain.review.entity.Review;
+import com.seohaeng.backend.domain.user.entity.User;
+
+public class ReviewConverter {
+
+    public static Review toReview(
+            ReviewRequestDTO.CreateReviewRequestDTO reviewRequestDTO, User user, Place place) {
+        return Review.builder()
+                .place(place)
+                .content(reviewRequestDTO.getContent())
+                .rating(reviewRequestDTO.getRating())
+                .visitedDate(reviewRequestDTO.getVisitedDate())
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/dto/ReviewRequestDTO.java
@@ -1,0 +1,32 @@
+package com.seohaeng.backend.domain.review.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class ReviewRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateReviewRequestDTO {
+
+        @NotNull(message = "평점은 필수입니다.")
+        @DecimalMin(value = "0.5", inclusive = true, message = "평점은 최소 0.5 이상이어야 합니다.")
+        @DecimalMax(value = "5.0", inclusive = true, message = "평점은 최대 5.0 이하여야 합니다.")
+        private BigDecimal rating;
+
+        @NotNull(message = "방문일은 필수입니다.")
+        private LocalDate visitedDate;
+
+        @NotBlank(message = "리뷰 내용은 필수입니다.")
+        private String content;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/dto/ReviewResponseDTO.java
@@ -2,6 +2,10 @@ package com.seohaeng.backend.domain.review.dto;
 
 import lombok.*;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
 public class ReviewResponseDTO {
 
     @AllArgsConstructor
@@ -9,5 +13,36 @@ public class ReviewResponseDTO {
     @Getter
     public static class CreateReviewResponseDTO{
         private Long reviewId;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class GetReviewResponseDTO {
+        LocalDate createdAt;
+        Long creatorId;
+        Long PlaceId;
+        Long ReviewId;
+
+        BigDecimal rating;
+        String reviewContent;
+        List<String> reviewImageList;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class GetReviewListResponseDTO {
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+        Double totalReviewRating;
+        List<GetReviewResponseDTO> getReviewList;
     }
 }

--- a/src/main/java/com/seohaeng/backend/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/dto/ReviewResponseDTO.java
@@ -1,0 +1,13 @@
+package com.seohaeng.backend.domain.review.dto;
+
+import lombok.*;
+
+public class ReviewResponseDTO {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CreateReviewResponseDTO{
+        private Long reviewId;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/entity/Review.java
@@ -1,30 +1,37 @@
-package com.seohaeng.backend.domain.place.entity.review;
+package com.seohaeng.backend.domain.review.entity;
 
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.PastOrPresent;
+import lombok.*;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
 public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1000)
     private String content;
 
-    @Column(nullable = false)
-    private Integer rating;
+    @Column(nullable = false, precision = 2, scale = 1)
+    private BigDecimal rating;
 
-    private String imageUrl;
+    @PastOrPresent
+    @Column(nullable = false)
+    private LocalDate visitedDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/seohaeng/backend/domain/review/entity/ReviewImage.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/entity/ReviewImage.java
@@ -1,14 +1,14 @@
-package com.seohaeng.backend.domain.place.entity.review;
+package com.seohaeng.backend.domain.review.entity;
 
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
+@Builder
 public class ReviewImage extends BaseEntity {
 
     @Id

--- a/src/main/java/com/seohaeng/backend/domain/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/repository/ReviewImageRepository.java
@@ -1,0 +1,7 @@
+package com.seohaeng.backend.domain.review.repository;
+
+import com.seohaeng.backend.domain.review.entity.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+}

--- a/src/main/java/com/seohaeng/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,16 @@
 package com.seohaeng.backend.domain.review.repository;
 
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Page<Review> findAllByPlace(Place place, Pageable pageable);
+
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.place = :place")
+    Double getAverageRatingByPlace(@Param("place") Place place);
 }

--- a/src/main/java/com/seohaeng/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.seohaeng.backend.domain.review.repository;
+
+import com.seohaeng.backend.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/seohaeng/backend/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/service/ReviewCommandService.java
@@ -1,0 +1,76 @@
+package com.seohaeng.backend.domain.review.service;
+
+import com.seohaeng.backend.domain.place.entity.place.Place;
+import com.seohaeng.backend.domain.place.repository.PlaceRepository;
+import com.seohaeng.backend.domain.review.converter.ReviewConverter;
+import com.seohaeng.backend.domain.review.dto.ReviewRequestDTO;
+import com.seohaeng.backend.domain.review.dto.ReviewResponseDTO;
+import com.seohaeng.backend.domain.review.entity.Review;
+import com.seohaeng.backend.domain.review.entity.ReviewImage;
+import com.seohaeng.backend.domain.review.repository.ReviewImageRepository;
+import com.seohaeng.backend.domain.review.repository.ReviewRepository;
+import com.seohaeng.backend.domain.user.entity.User;
+import com.seohaeng.backend.domain.user.repository.UserRepository;
+import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;
+import com.seohaeng.backend.global.apiPayload.exception.handler.PlaceHandler;
+import com.seohaeng.backend.global.apiPayload.exception.handler.ReviewHandler;
+import com.seohaeng.backend.global.apiPayload.exception.handler.UserHandler;
+import com.seohaeng.backend.global.aws.s3.AmazonS3Manager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewCommandService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
+    private final UserRepository userRepository;
+    private final PlaceRepository placeRepository;
+    private final AmazonS3Manager amazonS3Manager;
+
+    @Transactional
+    public ReviewResponseDTO.CreateReviewResponseDTO createReview(
+            ReviewRequestDTO.CreateReviewRequestDTO request,
+            Long userId,
+            Long placeId,
+            List<MultipartFile> images) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Place place = placeRepository.findById(placeId).
+                orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
+
+        if (request.getRating().multiply(BigDecimal.valueOf(2)).stripTrailingZeros().scale() > 0) {
+            throw new ReviewHandler(ErrorStatus.REVIEW_INVALID_ISSUE);
+        }
+
+        Review newReview = ReviewConverter.toReview(request, user, place);
+        reviewRepository.save(newReview);
+
+        List<ReviewImage> reviewImageList = new ArrayList<>();
+        if(images != null && !images.isEmpty()){
+            for (MultipartFile image : images) {
+                final String uuid = UUID.randomUUID().toString();
+                final String keyName = amazonS3Manager.generateReviewKeyName(uuid);
+                final String imageUrl = amazonS3Manager.uploadFile(keyName, image);
+
+                ReviewImage reviewImage = ReviewImage.builder()
+                        .imageUrl(imageUrl)
+                        .review(newReview)
+                        .build();
+                reviewImageList.add(reviewImage);
+            }
+            reviewImageRepository.saveAll(reviewImageList);
+        }
+        return new ReviewResponseDTO.CreateReviewResponseDTO(newReview.getId());
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/seohaeng/backend/domain/review/service/ReviewQueryService.java
@@ -1,0 +1,51 @@
+package com.seohaeng.backend.domain.review.service;
+
+import com.seohaeng.backend.domain.place.entity.place.Place;
+import com.seohaeng.backend.domain.place.repository.PlaceRepository;
+import com.seohaeng.backend.domain.review.converter.ReviewConverter;
+import com.seohaeng.backend.domain.review.dto.ReviewResponseDTO;
+import com.seohaeng.backend.domain.review.entity.Review;
+import com.seohaeng.backend.domain.review.entity.ReviewImage;
+import com.seohaeng.backend.domain.review.repository.ReviewImageRepository;
+import com.seohaeng.backend.domain.review.repository.ReviewRepository;
+import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;
+import com.seohaeng.backend.global.apiPayload.exception.handler.PlaceHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewQueryService {
+
+    private final ReviewRepository reviewRepository;
+    private final PlaceRepository placeRepository;
+
+    public ReviewResponseDTO.GetReviewListResponseDTO getReviewList(Integer page, Integer size, Long placeId){
+
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
+
+        Double averageRating = Optional.ofNullable(reviewRepository.getAverageRatingByPlace(place))
+                .orElse(0.0);
+
+        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        Page<Review> reviewPage = reviewRepository.findAllByPlace(place, pageRequest);
+
+        List<ReviewResponseDTO.GetReviewResponseDTO> getReviewList = reviewPage.getContent().stream()
+                .map(review -> {
+                    List<String> reviewImageList = review.getReviewImageList().stream()
+                            .map(ReviewImage::getImageUrl)
+                            .toList();
+                    return ReviewConverter.toGetReviewResponseDTO(review, reviewImageList);
+                })
+                .toList();
+        return ReviewConverter.toGetReviewListResponseDTO(reviewPage,getReviewList,averageRating);
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/travelCourse/converter/TravelCourseConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/travelCourse/converter/TravelCourseConverter.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.travelCourse.converter;
 
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.travelCourse.dto.TravelCourseRequestDTO;
 import com.seohaeng.backend.domain.travelCourse.dto.TravelCourseResponseDTO;
 import com.seohaeng.backend.domain.travelCourse.entity.*;

--- a/src/main/java/com/seohaeng/backend/domain/travelCourse/entity/TravelCourseSchedule.java
+++ b/src/main/java/com/seohaeng/backend/domain/travelCourse/entity/TravelCourseSchedule.java
@@ -1,7 +1,7 @@
 package com.seohaeng.backend.domain.travelCourse.entity;
 
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/seohaeng/backend/domain/travelCourse/service/TravelCourseCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/travelCourse/service/TravelCourseCommandService.java
@@ -1,6 +1,6 @@
 package com.seohaeng.backend.domain.travelCourse.service;
 
-import com.seohaeng.backend.domain.place.entity.Place;
+import com.seohaeng.backend.domain.place.entity.place.Place;
 import com.seohaeng.backend.domain.place.repository.PlaceRepository;
 import com.seohaeng.backend.domain.travelCourse.converter.TravelCourseConverter;
 import com.seohaeng.backend.domain.travelCourse.dto.TravelCourseRequestDTO;

--- a/src/main/java/com/seohaeng/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/seohaeng/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -39,7 +39,11 @@ public enum ErrorStatus implements BaseErrorCode {
     TRAVEL_COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "TRAVEL_COURSE_4001", "존재하지 않는 여행 일정입니다. 여행 일정 ID를 다시 확인해주세요"),
 
     // 북챌린지 관련
-    BOOK_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_CHALLENGE_4001", "존재하지 않는 게시글입니다.");
+    BOOK_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_CHALLENGE_4001", "존재하지 않는 게시글입니다."),
+
+    // 리뷰 관련
+    REVIEW_INVALID_ISSUE(HttpStatus.BAD_REQUEST, "REVIEW_4001", "리뷰 별점은 0.5점 단위로 입력해야합니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/seohaeng/backend/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/seohaeng/backend/global/apiPayload/code/status/SuccessStatus.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus implements BaseCode {
 
     _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
-    BOOK_CHALLENGE_PROOF_LIKE_TOGGLED(HttpStatus.OK, "BOOK_CHALLENGE2001", "북챌린지 게시글 좋아요 토글이 완료되었습니다.");
+    BOOK_CHALLENGE_PROOF_LIKE_TOGGLED(HttpStatus.OK, "BOOK_CHALLENGE2001", "북챌린지 게시글 좋아요 토글이 완료되었습니다."),
+    REVIEW_CREATE_SUCCESS(HttpStatus.OK, "REVIEW_2001", "리뷰 작성이 완료되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/seohaeng/backend/global/apiPayload/exception/handler/ReviewHandler.java
+++ b/src/main/java/com/seohaeng/backend/global/apiPayload/exception/handler/ReviewHandler.java
@@ -1,0 +1,10 @@
+package com.seohaeng.backend.global.apiPayload.exception.handler;
+
+import com.seohaeng.backend.global.apiPayload.code.BaseErrorCode;
+import com.seohaeng.backend.global.apiPayload.exception.GeneralException;
+
+public class ReviewHandler extends GeneralException {
+    public ReviewHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/seohaeng/backend/global/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/seohaeng/backend/global/aws/s3/AmazonS3Manager.java
@@ -29,6 +29,7 @@ public class AmazonS3Manager {
                     new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), objectMetadata));
         } catch (IOException e) {
             log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+            throw new RuntimeException("S3 업로드 오류 발생", e);
         }
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
@@ -52,5 +53,9 @@ public class AmazonS3Manager {
 
     public String generateBookChallengeProofKeyName(String uuid) {
         return amazonConfig.getBookChallengePath() + '/' + uuid;
+    }
+
+    public String generateReviewKeyName(String uuid) {
+        return amazonConfig.getReviewPath() + '/' + uuid;
     }
 }

--- a/src/main/java/com/seohaeng/backend/global/configuration/AmazonConfig.java
+++ b/src/main/java/com/seohaeng/backend/global/configuration/AmazonConfig.java
@@ -33,6 +33,9 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.path.bookchallenge}")
     private String bookChallengePath;
 
+    @Value("${cloud.aws.s3.path.review}")
+    private String reviewPath;
+
     @PostConstruct
     public void init() {
         this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,7 @@ cloud:
       bucket: ${AWS_S3_BUCKET}
       path:
         bookchallenge: bookchallenges
+        review: reviews
     region:
       static: ${AWS_REGION}
     stack:


### PR DESCRIPTION
## 📌 작업 내용

> ### Place 엔티티 구조 변경
> 기획이 변경되어 Place 테이블 구조와 엔티티가 변경되었습니다. 자세한 사항은 ERD 확인 부탁드립니다.
>
>###  리뷰 관련 API 구현
> 리뷰 작성, 장소별 리뷰 목록 조회 API를 구현하였습니다.

## ✨ 참고 사항
> 독립서점 이외의 유형인 장소의 상세정보 화면이 나오면 각 장소의 유형별 attribute 엔티티가 새로 추가될 예정입니다. 현재는 Place 유형이 독립서점일 경우에만 해당 엔티티가 존재합니다. 상세정보 화면 관련 API는 아직 변동 가능성이 매우 크기에 개발하지 말아주세요

## 🧩 연관 이슈
> #22 close 


<br>