### PR TITLE
✨[Feat] 회원 도메인 API 추가 및 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
 	// WebClient 사용을 위한 WebFlux 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
@@ -68,6 +68,12 @@ public class UserController {
         return ApiResponse.onSuccess(userCommandService.naverLogin(code));
     }
 
+    @Operation(summary = "구글 로그인 API", description = "구글 로그인 및 회원 가입을 진행하는 API입니다. 인가코드를 넘겨주세요.")
+    @GetMapping("/auth/google")
+    public ApiResponse<UserResponseDTO.LoginResultDTO> googleLogin(@RequestParam("code") String code) {
+        return ApiResponse.onSuccess(userCommandService.googleLogin(code));
+    }
+
     @Operation(summary = "닉네임 중복확인 API", description = "닉네임 중복확인을 진행하는 API입니다.")
     @GetMapping("/auth/check-nickname")
     public ApiResponse<String> checkNickname(

--- a/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
@@ -77,18 +77,18 @@ public class UserController {
     @Operation(summary = "닉네임 중복확인 API", description = "닉네임 중복확인을 진행하는 API입니다.")
     @GetMapping("/auth/check-nickname")
     public ApiResponse<String> checkNickname(
-            @AuthUser Long userId,
+            HttpServletRequest httpServletRequest,
             @RequestParam String nickname) {
-        String result = userQueryService.checkNickname(userId, nickname);
+        String result = userQueryService.checkNickname(httpServletRequest, nickname);
         return ApiResponse.onSuccess(result);
     }
 
     @Operation(summary = "아이디 중복확인 API", description = "아이디 중복확인을 진행하는 API입니다.")
     @GetMapping("/auth/check-username")
     public ApiResponse<String> checkUsername(
-            @AuthUser Long userId,
+            HttpServletRequest request,
             @RequestParam String username) {
-        String result = userQueryService.checkUsername(userId, username);
+        String result = userQueryService.checkUsername(request, username);
         return ApiResponse.onSuccess(result);
     }
 

--- a/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
@@ -62,6 +62,12 @@ public class UserController {
         return ApiResponse.onSuccess(userCommandService.kakaoLogin(code));
     }
 
+    @Operation(summary = "네이버 로그인 API", description = "네이버 로그인 및 회원 가입을 진행하는 API입니다. 인가코드를 넘겨주세요.")
+    @GetMapping("/auth/naver")
+    public ApiResponse<UserResponseDTO.LoginResultDTO> naverLogin(@RequestParam("code") String code) {
+        return ApiResponse.onSuccess(userCommandService.naverLogin(code));
+    }
+
     @Operation(summary = "닉네임 중복확인 API", description = "닉네임 중복확인을 진행하는 API입니다.")
     @GetMapping("/auth/check-nickname")
     public ApiResponse<String> checkNickname(

--- a/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.seohaeng.backend.domain.user.service.UserQueryService;
 import com.seohaeng.backend.global.apiPayload.ApiResponse;
 import com.seohaeng.backend.global.security.handler.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -87,9 +88,12 @@ public class UserController {
     public ApiResponse<UserResponseDTO.GetUserInfoResponseDTO> updateMyInfo(
             @AuthUser Long userId,
             @Valid @RequestPart("request") UserRequestDTO.updateProfileDTO request,
-            @RequestPart(value = "profileImage", required = false) MultipartFile image
+            @RequestPart(value = "profileImage", required = false) 
+            @Parameter(description = "업로드할 프로필 이미지 파일") MultipartFile image,
+            @RequestParam(value = "useDefault", required = false, defaultValue = "false") 
+            @Parameter(description = "기본 프로필 사진 사용 여부 (true: 기본 프로필로 변경, false: 업로드된 이미지 사용)") Boolean useDefault
     ) {
-        UserResponseDTO.GetUserInfoResponseDTO result = userCommandService.updateUserInfo(userId, request, image);
+        UserResponseDTO.GetUserInfoResponseDTO result = userCommandService.updateUserInfo(userId, request, useDefault, image);
         return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
@@ -51,9 +51,8 @@ public class UserController {
     @Operation(summary = "회원 탈퇴", description = "현재 사용자의 회원 탈퇴를 진행합니다.")
     @DeleteMapping
     public ApiResponse<String> deleteAccount(
-            @AuthUser Long userId,
-            @RequestBody  UserRequestDTO.DeleteAccountDTO password){
-        userCommandService.deleteUser(userId, password);
+            @AuthUser Long userId){
+        userCommandService.deleteUser(userId);
         return ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다.");
     }
 

--- a/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.seohaeng.backend.global.apiPayload.ApiResponse;
 import com.seohaeng.backend.global.security.handler.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -21,6 +22,15 @@ public class UserController {
 
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
+
+    @Operation(
+            summary = "JWT Access Token 재발급 API",
+            description = "Refresh Token 을 검증하고 새로운 Access Token 과 Refresh Token 을 응답합니다.")
+    @PostMapping("/reissue")
+    public ApiResponse<UserResponseDTO.TokenResponse> reissueToken(final HttpServletRequest request) {
+        UserResponseDTO.TokenResponse result = userCommandService.reissueToken(request);
+        return ApiResponse.onSuccess(result);
+    }
 
     @Operation(summary = "일반 회원가입 API",
             description = "아이디는 4~12자이며, 비밀번호는 8~20자이고 영문, 숫자, 특수문자를 반드시 포함해야 합니다." +

--- a/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/controller/UserController.java
@@ -38,6 +38,15 @@ public class UserController {
         return ApiResponse.onSuccess(userCommandService.loginUser(request));
     }
 
+    @Operation(summary = "회원 탈퇴", description = "현재 사용자의 회원 탈퇴를 진행합니다.")
+    @DeleteMapping
+    public ApiResponse<String> deleteAccount(
+            @AuthUser Long userId,
+            @RequestBody  UserRequestDTO.DeleteAccountDTO password){
+        userCommandService.deleteUser(userId, password);
+        return ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다.");
+    }
+
     @Operation(summary = "카카오 로그인 API", description = "카카오 로그인 및 회원 가입을 진행하는 API입니다. 인가코드를 넘겨주세요.")
     @GetMapping("/auth/kakao")
     public ApiResponse<UserResponseDTO.LoginResultDTO> kakaoLogin(@RequestParam("code") String code) {

--- a/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
@@ -47,10 +47,12 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.LoginResultDTO toLoginResultDTO(Long userId,String accessToken){
+    public static UserResponseDTO.LoginResultDTO toLoginResultDTO(
+            Long userId,String accessToken, String refreshToken){
         return UserResponseDTO.LoginResultDTO.builder()
                 .UserId(userId)
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
@@ -36,7 +36,7 @@ public class UserConverter {
 
     public static LoginInfo toKakaoLoginInfo(KakaoProfile kakaoProfile, User user){
         return LoginInfo.builder()
-                .username(kakaoProfile.getKakaoAccount().getEmail())
+                .username("KAKAO_" + kakaoProfile.getId())
                 .password("SOCIAL_LOGIN")
                 .provider(Provider.KAKAO)
                 .user(user)
@@ -55,7 +55,7 @@ public class UserConverter {
 
     public static LoginInfo toNaverLoginInfo(NaverProfile naverProfile, User user){
         return LoginInfo.builder()
-                .username(naverProfile.getNaverAccount().getEmail())
+                .username("NAVER_" + naverProfile.getNaverAccount().getId())
                 .password("SOCIAL_LOGIN")
                 .provider(Provider.NAVER)
                 .user(user)
@@ -74,7 +74,7 @@ public class UserConverter {
 
     public static LoginInfo toGoogleLoginInfo(GoogleProfile googleProfile, User user){
         return LoginInfo.builder()
-                .username(googleProfile.getEmail())
+                .username("GOOGLE_" + googleProfile.getSub())
                 .password("SOCIAL_LOGIN")
                 .provider(Provider.GOOGLE)
                 .user(user)

--- a/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
@@ -1,9 +1,6 @@
 package com.seohaeng.backend.domain.user.converter;
 
-import com.seohaeng.backend.domain.user.dto.KakaoProfile;
-import com.seohaeng.backend.domain.user.dto.NaverProfile;
-import com.seohaeng.backend.domain.user.dto.UserRequestDTO;
-import com.seohaeng.backend.domain.user.dto.UserResponseDTO;
+import com.seohaeng.backend.domain.user.dto.*;
 import com.seohaeng.backend.domain.user.entity.LoginInfo;
 import com.seohaeng.backend.domain.user.entity.Provider;
 import com.seohaeng.backend.domain.user.entity.User;
@@ -61,6 +58,25 @@ public class UserConverter {
                 .username(naverProfile.getNaverAccount().getEmail())
                 .password("SOCIAL_LOGIN")
                 .provider(Provider.NAVER)
+                .user(user)
+                .build();
+    }
+
+    public static User googleToUser(GoogleProfile googleProfile){
+        String email = googleProfile.getEmail();
+        String nickname = email.substring(0, email.indexOf('@'));
+
+        return User.builder()
+                .nickname("google#" + nickname)
+                .imageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png")
+                .build();
+    }
+
+    public static LoginInfo toGoogleLoginInfo(GoogleProfile googleProfile, User user){
+        return LoginInfo.builder()
+                .username(googleProfile.getEmail())
+                .password("SOCIAL_LOGIN")
+                .provider(Provider.GOOGLE)
                 .user(user)
                 .build();
     }

--- a/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
@@ -14,6 +14,7 @@ public class UserConverter {
     public static User toUser(UserRequestDTO.joinDTO request){
         User user = User.builder()
                 .nickname(request.getNickname())
+                .imageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png")
                 .build();
         return user;
     }
@@ -33,6 +34,7 @@ public class UserConverter {
 
         return User.builder()
                 .nickname("kakao#" + nickname)
+                .imageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png")
                 .build();
     }
 

--- a/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
@@ -4,6 +4,7 @@ import com.seohaeng.backend.domain.user.dto.*;
 import com.seohaeng.backend.domain.user.entity.LoginInfo;
 import com.seohaeng.backend.domain.user.entity.Provider;
 import com.seohaeng.backend.domain.user.entity.User;
+import java.util.UUID;
 
 public class UserConverter {
 
@@ -27,9 +28,10 @@ public class UserConverter {
     public static User kakaoToUser(KakaoProfile kakaoProfile){
         String email = kakaoProfile.getKakaoAccount().getEmail();
         String nickname = email.substring(0, email.indexOf('@'));
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8);
 
         return User.builder()
-                .nickname("kakao#" + nickname)
+                .nickname("kakao#" + nickname + "_" + uniqueId)
                 .imageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png")
                 .build();
     }
@@ -46,9 +48,10 @@ public class UserConverter {
     public static User naverToUser(NaverProfile naverProfile){
         String email = naverProfile.getNaverAccount().getEmail();
         String nickname = email.substring(0, email.indexOf('@'));
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8);
 
         return User.builder()
-                .nickname("naver#" + nickname)
+                .nickname("naver#" + nickname + "_" + uniqueId)
                 .imageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png")
                 .build();
     }
@@ -65,9 +68,10 @@ public class UserConverter {
     public static User googleToUser(GoogleProfile googleProfile){
         String email = googleProfile.getEmail();
         String nickname = email.substring(0, email.indexOf('@'));
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8);
 
         return User.builder()
-                .nickname("google#" + nickname)
+                .nickname("google#" + nickname + "_" + uniqueId)
                 .imageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png")
                 .build();
     }

--- a/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
@@ -1,13 +1,12 @@
 package com.seohaeng.backend.domain.user.converter;
 
 import com.seohaeng.backend.domain.user.dto.KakaoProfile;
+import com.seohaeng.backend.domain.user.dto.NaverProfile;
 import com.seohaeng.backend.domain.user.dto.UserRequestDTO;
 import com.seohaeng.backend.domain.user.dto.UserResponseDTO;
 import com.seohaeng.backend.domain.user.entity.LoginInfo;
 import com.seohaeng.backend.domain.user.entity.Provider;
 import com.seohaeng.backend.domain.user.entity.User;
-import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;
-import com.seohaeng.backend.global.apiPayload.exception.handler.UserHandler;
 
 public class UserConverter {
 
@@ -43,6 +42,25 @@ public class UserConverter {
                 .username(kakaoProfile.getKakaoAccount().getEmail())
                 .password("SOCIAL_LOGIN")
                 .provider(Provider.KAKAO)
+                .user(user)
+                .build();
+    }
+
+    public static User naverToUser(NaverProfile naverProfile){
+        String email = naverProfile.getNaverAccount().getEmail();
+        String nickname = email.substring(0, email.indexOf('@'));
+
+        return User.builder()
+                .nickname("naver#" + nickname)
+                .imageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png")
+                .build();
+    }
+
+    public static LoginInfo toNaverLoginInfo(NaverProfile naverProfile, User user){
+        return LoginInfo.builder()
+                .username(naverProfile.getNaverAccount().getEmail())
+                .password("SOCIAL_LOGIN")
+                .provider(Provider.NAVER)
                 .user(user)
                 .build();
     }

--- a/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/converter/UserConverter.java
@@ -105,6 +105,7 @@ public class UserConverter {
     public static UserResponseDTO.GetMyInfoResponseDTO toMyInfoDTO(User user, LoginInfo loginInfo) {
         return UserResponseDTO.GetMyInfoResponseDTO.builder()
                 .userId(user.getId())
+                .userName(user.getLoginInfo().getUsername())
                 .nickName(user.getNickname())
                 .profileImageUrl(user.getImageUrl())
                 .loginType(loginInfo.getProvider())

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/GoogleProfile.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/GoogleProfile.java
@@ -1,0 +1,10 @@
+package com.seohaeng.backend.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleProfile {
+    private String email;
+}

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/GoogleProfile.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/GoogleProfile.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GoogleProfile {
     private String email;
+    private String sub;
 }

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/KakaoProfile.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/KakaoProfile.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoProfile {
 
+    private Long id;
+
     @JsonProperty("kakao_account")
     private KakaoAccount kakaoAccount;
 

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/NaverProfile.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/NaverProfile.java
@@ -15,5 +15,6 @@ public class NaverProfile {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class NaverAccount {
         private String email;
+        private String id;
     }
 }

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/NaverProfile.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/NaverProfile.java
@@ -1,0 +1,19 @@
+package com.seohaeng.backend.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverProfile {
+
+    @JsonProperty("response")
+    private NaverAccount naverAccount;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class NaverAccount {
+        private String email;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/UserRequestDTO.java
@@ -50,10 +50,4 @@ public class UserRequestDTO {
         @Size(min = 8, max = 20)
         private String password2;
     }
-
-    @Getter
-    public static class DeleteAccountDTO{
-        @NotBlank(message = "탈퇴를 위해 비밀번호 입력은 필수입니다.")
-        private String password;
-    }
 }

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/UserRequestDTO.java
@@ -50,4 +50,10 @@ public class UserRequestDTO {
         @Size(min = 8, max = 20)
         private String password2;
     }
+
+    @Getter
+    public static class DeleteAccountDTO{
+        @NotBlank(message = "탈퇴를 위해 비밀번호 입력은 필수입니다.")
+        private String password;
+    }
 }

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/UserResponseDTO.java
@@ -1,10 +1,7 @@
 package com.seohaeng.backend.domain.user.dto;
 
 import com.seohaeng.backend.domain.user.entity.Provider;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 public class UserResponseDTO {
 
@@ -37,5 +34,14 @@ public class UserResponseDTO {
         String nickName;
         String profileImageUrl;
         Provider loginType;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenResponse {
+        String accessToken;
+        String refreshToken;
     }
 }

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/UserResponseDTO.java
@@ -15,6 +15,7 @@ public class UserResponseDTO {
     public static class LoginResultDTO {
         Long UserId;
         String accessToken;
+        String refreshToken;
     }
 
     @Builder

--- a/src/main/java/com/seohaeng/backend/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/dto/UserResponseDTO.java
@@ -31,6 +31,7 @@ public class UserResponseDTO {
     @AllArgsConstructor
     public static class GetMyInfoResponseDTO {
         Long userId;
+        String userName;
         String nickName;
         String profileImageUrl;
         Provider loginType;

--- a/src/main/java/com/seohaeng/backend/domain/user/entity/User.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/entity/User.java
@@ -1,7 +1,12 @@
 package com.seohaeng.backend.domain.user.entity;
 
 import com.seohaeng.backend.domain.bookChallenge.entity.BookChallenge;
+import com.seohaeng.backend.domain.bookChallenge.entity.BookChallengeProof;
+import com.seohaeng.backend.domain.bookChallenge.entity.BookChallengeProofComment;
 import com.seohaeng.backend.domain.common.entity.BaseEntity;
+import com.seohaeng.backend.domain.readingSpot.entity.ReadingSpot;
+import com.seohaeng.backend.domain.readingSpot.entity.ReadingSpotComment;
+import com.seohaeng.backend.domain.readingSpot.entity.ReadingSpotLike;
 import com.seohaeng.backend.domain.readingSpot.entity.ReadingSpotScrap;
 import com.seohaeng.backend.domain.travelCourse.entity.Stamp;
 import com.seohaeng.backend.domain.travelCourse.entity.TravelCourse;
@@ -31,18 +36,31 @@ public class User extends BaseEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private LoginInfo loginInfo;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<BookChallenge> bookChallengeBooks = new ArrayList<>();
+    // 독립 서점 사장 여부
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Owner owner;
 
+    // 북 챌린지
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Stamp> stampList = new ArrayList<>();
-
+    private List<BookChallenge> bookChallenges = new ArrayList<>();
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<TravelCourse> travelCourses = new ArrayList<>();
+    private List<BookChallengeProof> bookChallengeProofList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<BookChallengeProofComment> bookChallengeProofCommentList = new ArrayList<>();
 
+    // 공간 책갈피
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ReadingSpot> readingSpotList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ReadingSpotLike> readingSpotLikeList = new ArrayList<>();
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<ReadingSpotScrap> readingSpotScrapList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ReadingSpotComment> readingSpotCommentList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user")
-    private Owner owner; // 독립 서점 사장 여부
+    // 여행 일정
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Stamp> stampList = new ArrayList<>();
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<TravelCourse> travelCourses = new ArrayList<>();
 }

--- a/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
@@ -1,10 +1,7 @@
 package com.seohaeng.backend.domain.user.service;
 
 import com.seohaeng.backend.domain.user.converter.UserConverter;
-import com.seohaeng.backend.domain.user.dto.KakaoProfile;
-import com.seohaeng.backend.domain.user.dto.OAuthToken;
-import com.seohaeng.backend.domain.user.dto.UserRequestDTO;
-import com.seohaeng.backend.domain.user.dto.UserResponseDTO;
+import com.seohaeng.backend.domain.user.dto.*;
 import com.seohaeng.backend.domain.user.entity.LoginInfo;
 import com.seohaeng.backend.domain.user.entity.Provider;
 import com.seohaeng.backend.domain.user.entity.User;
@@ -14,7 +11,8 @@ import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;
 import com.seohaeng.backend.global.apiPayload.exception.handler.AuthException;
 import com.seohaeng.backend.global.apiPayload.exception.handler.UserHandler;
 import com.seohaeng.backend.global.aws.s3.AmazonS3Manager;
-import com.seohaeng.backend.global.security.KakaoAuthProvider;
+import com.seohaeng.backend.global.security.authProvider.KakaoAuthProvider;
+import com.seohaeng.backend.global.security.authProvider.NaverAuthProvider;
 import com.seohaeng.backend.global.security.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +42,7 @@ public class UserCommandService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, Object> redisTemplate;
     private final KakaoAuthProvider kakaoAuthProvider;
+    private final NaverAuthProvider naverAuthProvider;
     private final AmazonS3Manager amazonS3Manager;
 
     @Value("${jwt.token.expiration.refresh}")
@@ -167,6 +166,31 @@ public class UserCommandService {
         return getOauthResponseForUser(loginInfo);
     }
 
+    // 네이버 로그인
+    @Transactional
+    public UserResponseDTO.LoginResultDTO naverLogin(String code) {
+        OAuthToken oAuthToken = getNaverOauthToken(code);
+
+        NaverProfile naverProfile;
+        try {
+            naverProfile = naverAuthProvider.requestNaverProfile(oAuthToken.getAccess_token());
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+        }
+
+        Optional<LoginInfo> userLoginInfo = loginInfoRepository.findByUsername(naverProfile.getNaverAccount().getEmail());
+
+        if (userLoginInfo.isPresent()) {
+            LoginInfo logininfo = userLoginInfo.get();
+            return getOauthResponseForUser(logininfo);
+        }
+
+        User user = userRepository.save(UserConverter.naverToUser(naverProfile));
+        LoginInfo loginInfo = loginInfoRepository.save(UserConverter.toNaverLoginInfo(naverProfile,user));
+
+        return getOauthResponseForUser(loginInfo);
+    }
+
     // 회원 탈퇴
     @Transactional
     public void deleteUser(Long userId){
@@ -274,6 +298,16 @@ public class UserCommandService {
         OAuthToken oAuthToken;
         try {
             oAuthToken = kakaoAuthProvider.requestToken(code);
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
+        }
+        return oAuthToken;
+    }
+
+    private OAuthToken getNaverOauthToken(String code) {
+        OAuthToken oAuthToken;
+        try {
+            oAuthToken = naverAuthProvider.requestToken(code);
         } catch (Exception e) {
             throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
         }

--- a/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
@@ -103,6 +103,7 @@ public class UserCommandService {
     public UserResponseDTO.GetUserInfoResponseDTO updateUserInfo(
             Long userId,
             UserRequestDTO.updateProfileDTO request,
+            Boolean useDefault,
             MultipartFile image){
 
         User user = userRepository.findUserWithLoginInfoById(userId)
@@ -142,12 +143,15 @@ public class UserCommandService {
             loginInfo.setPassword(encodedPassword);
         } // 비밀번호 변경
 
-        if (image != null && !image.isEmpty()) {
+        // 프로필 이미지 변경
+        if (Boolean.TRUE.equals(useDefault)) {
+            user.setImageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png");
+        } else if (Boolean.FALSE.equals(useDefault) && image != null && !image.isEmpty()) {
             final String uuid = UUID.randomUUID().toString();
             final String keyName = amazonS3Manager.generateProfileKeyName(uuid);
             final String imageUrl = amazonS3Manager.uploadFile(keyName, image);
             user.setImageUrl(imageUrl);
-        } // 프로필 이미지 변경
+        }
 
         return toUserInfoDTO(user);
     }

--- a/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
@@ -169,7 +169,7 @@ public class UserCommandService {
 
     // 회원 탈퇴
     @Transactional
-    public void deleteUser(Long userId, UserRequestDTO.DeleteAccountDTO password){
+    public void deleteUser(Long userId){
 
         User user = userRepository.findUserWithLoginInfoById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
@@ -177,13 +177,9 @@ public class UserCommandService {
         LoginInfo loginInfo = user.getLoginInfo();
         Provider provider = loginInfo.getProvider();
 
-        if(passwordEncoder.matches(password.getPassword(), loginInfo.getPassword())){
-            if(provider.equals(Provider.LOCAL)){
-                userRepository.delete(user);
-            } // TODO : 각 소셜 로그인 Provider 별로 처리
-        }else{
-            throw new UserHandler(ErrorStatus.PASSWORD_MISMATCH);
-        }
+        if(provider.equals(Provider.LOCAL)){
+            userRepository.delete(user);
+        } // TODO : 각 소셜 로그인 Provider 별로 처리
     }
 
     // 사용자 정보 변경

--- a/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
@@ -1,9 +1,5 @@
 package com.seohaeng.backend.domain.user.service;
 
-import com.seohaeng.backend.domain.bookChallenge.entity.BookChallengeProofImage;
-import com.seohaeng.backend.domain.travelCourse.converter.TravelCourseConverter;
-import com.seohaeng.backend.domain.travelCourse.entity.Stamp;
-import com.seohaeng.backend.domain.travelCourse.repository.StampRepository;
 import com.seohaeng.backend.domain.user.converter.UserConverter;
 import com.seohaeng.backend.domain.user.dto.KakaoProfile;
 import com.seohaeng.backend.domain.user.dto.OAuthToken;
@@ -21,7 +17,6 @@ import com.seohaeng.backend.global.aws.s3.AmazonS3Manager;
 import com.seohaeng.backend.global.security.KakaoAuthProvider;
 import com.seohaeng.backend.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -74,7 +69,7 @@ public class UserCommandService {
         return loginInfoRepository.save(joinLoginInfo);
     }
 
-    // 로그인
+    // 일반 로그인
     public UserResponseDTO.LoginResultDTO loginUser(UserRequestDTO.LoginDTO loginDTO) {
 
         LoginInfo loginUserLoginInfo = loginInfoRepository.findByUsernameWithUser(loginDTO.getUsername())
@@ -91,12 +86,39 @@ public class UserCommandService {
                 null,
                 Collections.emptyList());
 
-        String accessToken = jwtTokenProvider.generateToken(authentication);
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
 
         return UserConverter.toLoginResultDTO(
                 loginUser.getId(),
-                accessToken
+                accessToken,
+                refreshToken
         );
+    }
+
+    // 카카오 로그인
+    @Transactional
+    public UserResponseDTO.LoginResultDTO kakaoLogin(String code) {
+        OAuthToken oAuthToken = getKakaoOauthToken(code);
+
+        KakaoProfile kakaoProfile;
+        try {
+            kakaoProfile = kakaoAuthProvider.requestKakaoProfile(oAuthToken.getAccess_token());
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+        }
+
+        Optional<LoginInfo> userLoginInfo = loginInfoRepository.findByUsername(kakaoProfile.getKakaoAccount().getEmail());
+
+        if (userLoginInfo.isPresent()) {
+            LoginInfo logininfo = userLoginInfo.get();
+            return getOauthResponseForUser(logininfo);
+        }
+
+        User user = userRepository.save(UserConverter.kakaoToUser(kakaoProfile));
+        LoginInfo loginInfo = loginInfoRepository.save(UserConverter.toKakaoLoginInfo(kakaoProfile,user));
+
+        return getOauthResponseForUser(loginInfo);
     }
 
     // 회원 탈퇴
@@ -164,7 +186,6 @@ public class UserCommandService {
             loginInfo.setPassword(encodedPassword);
         } // 비밀번호 변경
 
-        // 프로필 이미지 변경
         if (Boolean.TRUE.equals(useDefault)) {
             user.setImageUrl("https://seohaeng-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default_profile.png");
         } else if (Boolean.FALSE.equals(useDefault) && image != null && !image.isEmpty()) {
@@ -172,7 +193,7 @@ public class UserCommandService {
             final String keyName = amazonS3Manager.generateProfileKeyName(uuid);
             final String imageUrl = amazonS3Manager.uploadFile(keyName, image);
             user.setImageUrl(imageUrl);
-        }
+        } // 프로필 이미지 변경
 
         return toUserInfoDTO(user);
     }
@@ -185,30 +206,6 @@ public class UserCommandService {
         }
     }
 
-    @Transactional
-    public UserResponseDTO.LoginResultDTO kakaoLogin(String code) {
-        OAuthToken oAuthToken = getKakaoOauthToken(code);
-
-        KakaoProfile kakaoProfile;
-        try {
-            kakaoProfile = kakaoAuthProvider.requestKakaoProfile(oAuthToken.getAccess_token());
-        } catch (Exception e) {
-            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
-        }
-
-        Optional<LoginInfo> userLoginInfo = loginInfoRepository.findByUsername(kakaoProfile.getKakaoAccount().getEmail());
-
-        if (userLoginInfo.isPresent()) {
-            LoginInfo logininfo = userLoginInfo.get();
-            return getOauthResponseForUser(logininfo);
-        }
-
-        User user = userRepository.save(UserConverter.kakaoToUser(kakaoProfile));
-        LoginInfo loginInfo = loginInfoRepository.save(UserConverter.toKakaoLoginInfo(kakaoProfile,user));
-
-        return getOauthResponseForUser(loginInfo);
-    }
-
     private UserResponseDTO.LoginResultDTO getOauthResponseForUser(LoginInfo logininfo) {
 
         Authentication authentication = new UsernamePasswordAuthenticationToken(
@@ -218,8 +215,9 @@ public class UserCommandService {
 
         User loginUser = logininfo.getUser();
 
-        String accessToken = jwtTokenProvider.generateToken(authentication);
-        return UserConverter.toLoginResultDTO(loginUser.getId(),accessToken);
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+        return UserConverter.toLoginResultDTO(loginUser.getId(),accessToken,refreshToken);
     }
 
     private OAuthToken getKakaoOauthToken(String code) {

--- a/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
@@ -21,6 +21,7 @@ import com.seohaeng.backend.global.aws.s3.AmazonS3Manager;
 import com.seohaeng.backend.global.security.KakaoAuthProvider;
 import com.seohaeng.backend.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -97,6 +98,26 @@ public class UserCommandService {
                 accessToken
         );
     }
+
+    // 회원 탈퇴
+    @Transactional
+    public void deleteUser(Long userId, UserRequestDTO.DeleteAccountDTO password){
+
+        User user = userRepository.findUserWithLoginInfoById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        LoginInfo loginInfo = user.getLoginInfo();
+        Provider provider = loginInfo.getProvider();
+
+        if(passwordEncoder.matches(password.getPassword(), loginInfo.getPassword())){
+            if(provider.equals(Provider.LOCAL)){
+                userRepository.delete(user);
+            } // TODO : 각 소셜 로그인 Provider 별로 처리
+        }else{
+            throw new UserHandler(ErrorStatus.PASSWORD_MISMATCH);
+        }
+    }
+
 
     // 사용자 정보 변경
     @Transactional

--- a/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
@@ -16,13 +16,18 @@ import com.seohaeng.backend.global.apiPayload.exception.handler.UserHandler;
 import com.seohaeng.backend.global.aws.s3.AmazonS3Manager;
 import com.seohaeng.backend.global.security.KakaoAuthProvider;
 import com.seohaeng.backend.global.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.Duration;
 
 import java.util.*;
 
@@ -37,8 +42,47 @@ public class UserCommandService {
     private final LoginInfoRepository loginInfoRepository;
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final KakaoAuthProvider kakaoAuthProvider;
     private final AmazonS3Manager amazonS3Manager;
+
+    @Value("${jwt.token.expiration.refresh}")
+    private long refreshTokenExpiration;
+
+    // 토큰 재발급
+    public UserResponseDTO.TokenResponse reissueToken(HttpServletRequest request) {
+        String refreshToken = jwtTokenProvider.extractToken(request);
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new UserHandler(ErrorStatus.INVALID_TOKEN);
+        }
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
+        String username = authentication.getName();
+
+        LoginInfo loginInfo = loginInfoRepository.findByUsernameWithUser(username)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        User user = loginInfo.getUser();
+        Long userId = user.getId();
+
+        String redisKey = "refreshToken:" + userId;
+        String storedRefreshToken = (String) redisTemplate.opsForValue().get(redisKey);
+
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+            throw new UserHandler(ErrorStatus.INVALID_TOKEN);
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(authentication);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+        saveRefreshTokenToRedis(userId, newRefreshToken);
+
+        return UserResponseDTO.TokenResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
 
     // 회원가입
     @Transactional
@@ -88,6 +132,8 @@ public class UserCommandService {
 
         String accessToken = jwtTokenProvider.createAccessToken(authentication);
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+        saveRefreshTokenToRedis(loginUser.getId(), refreshToken);
 
         return UserConverter.toLoginResultDTO(
                 loginUser.getId(),
@@ -139,7 +185,6 @@ public class UserCommandService {
             throw new UserHandler(ErrorStatus.PASSWORD_MISMATCH);
         }
     }
-
 
     // 사용자 정보 변경
     @Transactional
@@ -198,6 +243,12 @@ public class UserCommandService {
         return toUserInfoDTO(user);
     }
 
+    // Refresh Token Redis 저장
+    private void saveRefreshTokenToRedis(Long userId, String refreshToken) {
+        String redisKey = "refreshToken:" + userId;
+        redisTemplate.opsForValue().set(redisKey, refreshToken, Duration.ofMillis(refreshTokenExpiration));
+    }
+
     private void validatePasswordComplexity(String password) {
         String pattern = "^(?!.*[가-힣])(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).+$";
 
@@ -217,6 +268,9 @@ public class UserCommandService {
 
         String accessToken = jwtTokenProvider.createAccessToken(authentication);
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+        saveRefreshTokenToRedis(loginUser.getId(), refreshToken);
+
         return UserConverter.toLoginResultDTO(loginUser.getId(),accessToken,refreshToken);
     }
 

--- a/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/service/UserCommandService.java
@@ -11,6 +11,7 @@ import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;
 import com.seohaeng.backend.global.apiPayload.exception.handler.AuthException;
 import com.seohaeng.backend.global.apiPayload.exception.handler.UserHandler;
 import com.seohaeng.backend.global.aws.s3.AmazonS3Manager;
+import com.seohaeng.backend.global.security.authProvider.GoogleAuthProvider;
 import com.seohaeng.backend.global.security.authProvider.KakaoAuthProvider;
 import com.seohaeng.backend.global.security.authProvider.NaverAuthProvider;
 import com.seohaeng.backend.global.security.jwt.JwtTokenProvider;
@@ -43,6 +44,7 @@ public class UserCommandService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final KakaoAuthProvider kakaoAuthProvider;
     private final NaverAuthProvider naverAuthProvider;
+    private final GoogleAuthProvider googleAuthProvider;
     private final AmazonS3Manager amazonS3Manager;
 
     @Value("${jwt.token.expiration.refresh}")
@@ -175,7 +177,7 @@ public class UserCommandService {
         try {
             naverProfile = naverAuthProvider.requestNaverProfile(oAuthToken.getAccess_token());
         } catch (Exception e) {
-            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_NAVER);
         }
 
         Optional<LoginInfo> userLoginInfo = loginInfoRepository.findByUsername(naverProfile.getNaverAccount().getEmail());
@@ -187,6 +189,33 @@ public class UserCommandService {
 
         User user = userRepository.save(UserConverter.naverToUser(naverProfile));
         LoginInfo loginInfo = loginInfoRepository.save(UserConverter.toNaverLoginInfo(naverProfile,user));
+
+        return getOauthResponseForUser(loginInfo);
+    }
+
+    // 구글 로그인
+    @Transactional
+    public UserResponseDTO.LoginResultDTO googleLogin(String code) {
+        OAuthToken oAuthToken = getGoogleOauthToken(code);
+
+        GoogleProfile googleProfile;
+        try {
+            googleProfile = googleAuthProvider.requestGooglerofile(oAuthToken.getAccess_token());
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_GOOGLE);
+        }
+
+        Optional<LoginInfo> userLoginInfo
+                = loginInfoRepository.findByUsername(
+                googleProfile.getEmail());
+
+        if (userLoginInfo.isPresent()) {
+            LoginInfo logininfo = userLoginInfo.get();
+            return getOauthResponseForUser(logininfo);
+        }
+
+        User user = userRepository.save(UserConverter.googleToUser(googleProfile));
+        LoginInfo loginInfo = loginInfoRepository.save(UserConverter.toGoogleLoginInfo(googleProfile,user));
 
         return getOauthResponseForUser(loginInfo);
     }
@@ -308,6 +337,16 @@ public class UserCommandService {
         OAuthToken oAuthToken;
         try {
             oAuthToken = naverAuthProvider.requestToken(code);
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
+        }
+        return oAuthToken;
+    }
+
+    private OAuthToken getGoogleOauthToken(String code) {
+        OAuthToken oAuthToken;
+        try {
+            oAuthToken = googleAuthProvider.requestToken(code);
         } catch (Exception e) {
             throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
         }

--- a/src/main/java/com/seohaeng/backend/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/seohaeng/backend/domain/user/service/UserQueryService.java
@@ -7,6 +7,8 @@ import com.seohaeng.backend.domain.user.repository.LoginInfoRepository;
 import com.seohaeng.backend.domain.user.repository.UserRepository;
 import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;
 import com.seohaeng.backend.global.apiPayload.exception.handler.UserHandler;
+import com.seohaeng.backend.global.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +25,7 @@ public class UserQueryService {
 
     private final UserRepository userRepository;
     private final LoginInfoRepository loginInfoRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public UserResponseDTO.GetMyInfoResponseDTO getMyInfo(Long userId){
         User user = userRepository.findUserWithLoginInfoById(userId)
@@ -37,28 +40,52 @@ public class UserQueryService {
         return toUserInfoDTO(user);
     }
 
-    public String checkUsername(Long userId, String username) {
-        User user = userRepository.findUserWithLoginInfoById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+    public String checkUsername(HttpServletRequest request, String username) {
+        String token = jwtTokenProvider.resolveToken(request);
+        boolean exists = loginInfoRepository.existsByUsername(username);
+
+        if (token == null || !jwtTokenProvider.validateToken(token)) {
+            if (!exists) {
+                return "사용 가능한 아이디입니다.";
+            } else {
+                return "이미 사용 중인 아이디입니다.";
+            }
+        }
+
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        User user = userRepository.findUserWithLoginInfoById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
         String currentUsername = user.getLoginInfo().getUsername();
+        
         if (Objects.equals(currentUsername, username)) {
             return "현재 사용중이신 아이디입니다.";
-        }
-        boolean exists = loginInfoRepository.existsByUsername(username);
-        if (!exists) {
+        } else if (!exists) {
             return "사용 가능한 아이디입니다.";
         } else {
             return "이미 사용 중인 아이디입니다.";
         }
     }
 
-    public String checkNickname(Long userId, String nickname) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
-        String currentNickname = user.getNickname();
-        if (Objects.equals(currentNickname, nickname)) {
-            return "현재 사용중이신 닉네임입니다.";
-        }
+    public String checkNickname(HttpServletRequest request, String nickname) {
+        String token = jwtTokenProvider.resolveToken(request);
         boolean exists = userRepository.existsByNickname(nickname);
-        if (!exists) {
+
+        if (token == null || !jwtTokenProvider.validateToken(token)) {
+            if (!exists) {
+                return "사용 가능한 닉네임입니다.";
+            } else {
+                return "이미 사용 중인 닉네임입니다.";
+            }
+        }
+
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        String currentNickname = user.getNickname();
+        
+        if (Objects.equals(currentNickname, nickname)) {
+            return "현재 사용 중이신 닉네임입니다.";
+        } else if (!exists) {
             return "사용 가능한 닉네임입니다.";
         } else {
             return "이미 사용 중인 닉네임입니다.";

--- a/src/main/java/com/seohaeng/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/seohaeng/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -30,6 +30,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4001", "유효하지 않은 토큰입니다."),
     AUTH_EXTRACT_ERROR(HttpStatus.UNAUTHORIZED, "AUTH4002", "토큰 추출에 실패했습니다."),
     INVALID_REQUEST_INFO_KAKAO(HttpStatus.UNAUTHORIZED, "AUTH_007", "카카오 정보 불러오기에 실패하였습니다."),
+    INVALID_REQUEST_INFO_NAVER(HttpStatus.UNAUTHORIZED, "AUTH_008", "네이버 정보 불러오기에 실패하였습니다."),
     AUTH_INVALID_CODE(HttpStatus.UNAUTHORIZED, "", "코드가 유효하지 않습니다."),
 
     // 장소 관련

--- a/src/main/java/com/seohaeng/backend/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/seohaeng/backend/global/apiPayload/code/status/ErrorStatus.java
@@ -31,6 +31,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_EXTRACT_ERROR(HttpStatus.UNAUTHORIZED, "AUTH4002", "토큰 추출에 실패했습니다."),
     INVALID_REQUEST_INFO_KAKAO(HttpStatus.UNAUTHORIZED, "AUTH_007", "카카오 정보 불러오기에 실패하였습니다."),
     INVALID_REQUEST_INFO_NAVER(HttpStatus.UNAUTHORIZED, "AUTH_008", "네이버 정보 불러오기에 실패하였습니다."),
+    INVALID_REQUEST_INFO_GOOGLE(HttpStatus.UNAUTHORIZED, "AUTH_009", "구글 정보 불러오기에 실패하였습니다."),
     AUTH_INVALID_CODE(HttpStatus.UNAUTHORIZED, "", "코드가 유효하지 않습니다."),
 
     // 장소 관련

--- a/src/main/java/com/seohaeng/backend/global/redis/RedisConfig.java
+++ b/src/main/java/com/seohaeng/backend/global/redis/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.seohaeng.backend.global.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/global/security/authProvider/GoogleAuthProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/authProvider/GoogleAuthProvider.java
@@ -98,7 +98,6 @@ public class GoogleAuthProvider {
             throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_GOOGLE);
         }
 
-        System.out.println(googleProfile.getEmail());
         return googleProfile;
     }
 }

--- a/src/main/java/com/seohaeng/backend/global/security/authProvider/GoogleAuthProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/authProvider/GoogleAuthProvider.java
@@ -1,0 +1,104 @@
+package com.seohaeng.backend.global.security.authProvider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seohaeng.backend.domain.user.dto.GoogleProfile;
+import com.seohaeng.backend.domain.user.dto.OAuthToken;
+import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;
+import com.seohaeng.backend.global.apiPayload.exception.handler.AuthException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+@Getter
+public class GoogleAuthProvider {
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String client;
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String redirect;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String secret;
+
+    public OAuthToken requestToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Content-type"
+                ,"application/x-www-form-urlencoded;charset=utf-8");
+
+        String decode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", client);
+        params.add("redirect_uri", redirect);
+        params.add("client_secret", secret);
+        params.add("code", decode);
+
+        HttpEntity<MultiValueMap<String, String>> googleTokenRequest =
+                new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        "https://oauth2.googleapis.com/token",
+                        HttpMethod.POST,
+                        googleTokenRequest,
+                        String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        OAuthToken oAuthToken = null;
+
+        try {
+            oAuthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+        } catch (JsonProcessingException e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_GOOGLE);
+        }
+
+        return oAuthToken;
+    }
+
+    public GoogleProfile requestGooglerofile(String token) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization", "Bearer " + token);
+
+        HttpEntity<MultiValueMap<String, String>> googleProfileRequest = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        "https://www.googleapis.com/oauth2/v3/userinfo",
+                        HttpMethod.GET,
+                        googleProfileRequest,
+                        String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        GoogleProfile googleProfile = null;
+
+        try {
+            googleProfile = objectMapper.readValue(response.getBody(), GoogleProfile.class);
+        } catch (JsonProcessingException e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_GOOGLE);
+        }
+
+        System.out.println(googleProfile.getEmail());
+        return googleProfile;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/global/security/authProvider/KakaoAuthProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/authProvider/KakaoAuthProvider.java
@@ -1,4 +1,4 @@
-package com.seohaeng.backend.global.security;
+package com.seohaeng.backend.global.security.authProvider;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/seohaeng/backend/global/security/authProvider/KakaoAuthProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/authProvider/KakaoAuthProvider.java
@@ -87,7 +87,6 @@ public class KakaoAuthProvider {
         } catch (JsonProcessingException e) {
             throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
         }
-        System.out.println(kakaoProfile.getKakaoAccount().getEmail());
         return kakaoProfile;
     }
 }

--- a/src/main/java/com/seohaeng/backend/global/security/authProvider/NaverAuthProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/authProvider/NaverAuthProvider.java
@@ -1,0 +1,102 @@
+package com.seohaeng.backend.global.security.authProvider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seohaeng.backend.domain.user.dto.NaverProfile;
+import com.seohaeng.backend.domain.user.dto.OAuthToken;
+import com.seohaeng.backend.global.apiPayload.code.status.ErrorStatus;
+import com.seohaeng.backend.global.apiPayload.exception.handler.AuthException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Getter
+public class NaverAuthProvider {
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String client;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String secret;
+
+    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
+    private String redirect;
+
+    public OAuthToken requestToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Content-type"
+                ,"application/x-www-form-urlencoded;charset=utf-8");
+
+        String state = UUID.randomUUID().toString();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", client);
+        params.add("client_secret", secret);
+        params.add("redirect_uri", redirect);
+        params.add("state","test");
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> naverTokenRequest =
+                new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        "https://nid.naver.com/oauth2.0/token",
+                        HttpMethod.POST,
+                        naverTokenRequest,
+                        String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        OAuthToken oAuthToken = null;
+
+        try {
+            oAuthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+        } catch (JsonProcessingException e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+        }
+        return oAuthToken;
+    }
+
+    public NaverProfile requestNaverProfile(String token) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization", "Bearer " + token);
+
+        HttpEntity<MultiValueMap<String, String>> naverProfileRequest = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        "https://openapi.naver.com/v1/nid/me",
+                        HttpMethod.GET,
+                        naverProfileRequest,
+                        String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        NaverProfile naverProfile = null;
+        System.out.println(response.getBody());
+        try {
+            naverProfile = objectMapper.readValue(response.getBody(), NaverProfile.class);
+        } catch (JsonProcessingException e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_NAVER);
+        }
+        System.out.println(naverProfile.getNaverAccount().getEmail());
+        return naverProfile;
+    }
+}

--- a/src/main/java/com/seohaeng/backend/global/security/authProvider/NaverAuthProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/authProvider/NaverAuthProvider.java
@@ -96,7 +96,6 @@ public class NaverAuthProvider {
         } catch (JsonProcessingException e) {
             throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_NAVER);
         }
-        System.out.println(naverProfile.getNaverAccount().getEmail());
         return naverProfile;
     }
 }

--- a/src/main/java/com/seohaeng/backend/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/jwt/JwtTokenProvider.java
@@ -29,6 +29,9 @@ public class JwtTokenProvider {
 
     private final LoginInfoRepository loginInfoRepository;
 
+    private static final String HEADER_STRING = "Authorization";
+    private static final String HEADER_STRING_PREFIX = "Bearer ";
+
     @Value("${JWT_SECRET_KEY}")
     private String signingKey;
 
@@ -69,6 +72,17 @@ public class JwtTokenProvider {
         return generateToken(authentication, refreshTokenExpiration);
     }
 
+    // 토큰 추출
+    public String extractToken (final HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HEADER_STRING);
+
+        if (authorizationHeader != null && authorizationHeader.startsWith(HEADER_STRING_PREFIX)) {
+            return authorizationHeader.substring(7);
+        }
+        throw new UserHandler(ErrorStatus.INVALID_TOKEN);
+    }
+
+    // 토큰 유효성 검증
     public boolean validateToken(String token) {
         try{
             Jwts.parserBuilder()

--- a/src/main/java/com/seohaeng/backend/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/jwt/JwtTokenProvider.java
@@ -32,14 +32,17 @@ public class JwtTokenProvider {
     @Value("${JWT_SECRET_KEY}")
     private String signingKey;
 
+    @Value("${jwt.token.expiration.access}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.token.expiration.refresh}")
+    private long refreshTokenExpiration;
+
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(signingKey.getBytes(StandardCharsets.UTF_8));
     }
 
-    @Value("${jwt.token.expiration.access}")
-    private long accessTokenExpiration;
-
-    public String generateToken(Authentication authentication) {
+    public String generateToken(Authentication authentication, long validityMilliseconds) {
         String username = authentication.getName();
 
         LoginInfo loginUserLoginInfo = loginInfoRepository.findByUsernameWithUser(username)
@@ -53,9 +56,17 @@ public class JwtTokenProvider {
                 .setSubject(username)
                 .claim("id",UserId)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .setExpiration(new Date(System.currentTimeMillis() + validityMilliseconds))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        return generateToken(authentication, accessTokenExpiration);
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return generateToken(authentication, refreshTokenExpiration);
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/com/seohaeng/backend/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/seohaeng/backend/global/security/jwt/JwtTokenProvider.java
@@ -132,4 +132,14 @@ public class JwtTokenProvider {
         }
         return getAuthentication(accessToken);
     }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        
+        return claims.get("id", Long.class);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,11 +34,24 @@ spring:
             redirect-uri: ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-name: Kakao
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: ${NAVER_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            client-name: naver
+            scope:
+              - email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: id
 
 jwt:
   token:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,13 +33,21 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
-            client-name: Kakao
+            client-name: kakao
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             redirect-uri: ${NAVER_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-name: naver
+            scope:
+              - email
+          google:
+            client-authentication-method: client_secret_post
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            client-name: google
             scope:
               - email
         provider:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,8 @@ jwt:
   token:
     secretKey: ${JWT_SECRET_KEY}
     expiration:
-      access: 14400000
+      access: ${JWT_ACCESS_TOKEN_TIME}
+      refresh: ${JWT_REFRESH_TOKEN_TIME}
 
 cloud:
   aws:


### PR DESCRIPTION
## 📌 작업 내용

> 소셜 로그인 기능 추가/개선 및 사용자 정보 관련 API를 리팩토링했습니다:

 **기능 구현**
  - 네이버, 구글 소셜 로그인 추가: OAuth2를 통한 소셜 로그인 기능 구현
  - Refresh Token 발급 및 토큰 재발급, Redis Refresh Token 캐싱 구현

  **리팩토링**
  - 소셜 로그인 아이디 / 닉네임 생성 방식 개선: 각 소셜 플랫폼별 사용자명 생성 로직 중복 방지
  - 내 정보 조회 API 개선: 응답 DTO에 username 필드 추가
  - 중복 확인 API 개선: 토큰 유무에 따른 아이디/닉네임 중복 확인 응답 분기 처리

## ✨ 참고 사항

## 🧩 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성하세요. 예) close #19


<br>
