### PR TITLE
⚡️[Improve]  배포 속도 최적화

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,21 +10,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # 소스코드 체크아웃
       - name: Checkout code
         uses: actions/checkout@v3
 
+      # JDK 17 설정
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'zulu'
 
+      # application.yml을 Actions 환경에 복사
       - name: Copy application.yml from Secrets
         run: |
           mkdir -p deploy
           echo "${{ secrets.APPLICATION_YML }}" > deploy/application.yml
 
-      # Gradle 캐싱
+      # Gradle 캐싱, 의존성 재활용
       - name: Gradle Caching
         uses: actions/cache@v3
         with:
@@ -35,9 +38,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Run MySQL image for test
-        run: docker run -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=seohaeng_db mysql:8.0.31
-
+      # Gradle로 빌드 실행
       - name: Build with Gradle
         run: ./gradlew clean build -x test
 
@@ -46,6 +47,7 @@ jobs:
           cp build/libs/*.jar deploy/
           cp Dockerfile docker-compose.yml deploy/
 
+      # build 결과물을 아티팩트로 업로드
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -59,12 +61,14 @@ jobs:
       APP_PATH: ${{ secrets.APP_PATH }}
 
     steps:
+      # 아티팩트 다운로드
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: deploy/
 
+      # EC2로 빌드 파일 전송
       - name: SCP files to EC2
         uses: appleboy/scp-action@master
         with:
@@ -74,6 +78,7 @@ jobs:
           source: "deploy/*"
           target: ${{ env.APP_PATH }}
 
+      # 기존 컨테이너 정리, 최신 버전 배포
       - name: SSH deploy on EC2
         uses: appleboy/ssh-action@master
         with:


### PR DESCRIPTION
## 📌 작업 내용

> - Gradle 캐싱을 통해 Build with Gradle 작업 시간을 52초 -> 18초로 단축했습니다.
> - 불필요한 테스트 MySQL 컨테이너 단계를 삭제했습니다.
<img width="1280" height="216" alt="image" src="https://github.com/user-attachments/assets/9d4a610e-9458-4ead-95b9-67da4ce889b3" />


## ✨ 참고 사항

## 🧩 연관 이슈

> close #97


<br>