### PR TITLE
♻️[Refactor] TourismMarkerService DTO 프로젝션 적용으로 마커 조회 성능 개선

### DIFF
--- a/src/main/java/com/seohaeng/backend/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/repository/PlaceRepository.java
@@ -1,5 +1,6 @@
 package com.seohaeng.backend.domain.place.repository;
 
+import com.seohaeng.backend.domain.place.dto.PlaceMarkerDTO;
 import com.seohaeng.backend.domain.place.entity.enums.PlaceType;
 import com.seohaeng.backend.domain.place.entity.place.Place;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -26,9 +27,32 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     List<Place> findByNameContaining(String keyword);
 
-    List<Place> findByPlaceType(PlaceType placeType);
+    @Query("SELECT new com.seohaeng.backend.domain.place.dto.PlaceMarkerDTO(p.id, p.name, p.latitude, p.longitude) " +
+            "FROM Place p " +
+            "WHERE p.placeType = :placeType " +
+            "AND p.latitude IS NOT NULL AND p.longitude IS NOT NULL " +
+            "AND p.latitude BETWEEN :minLat AND :maxLat " +
+            "AND p.longitude BETWEEN :minLng AND :maxLng")
+    List<PlaceMarkerDTO> findMarkerDTOsByPlaceTypeAndBounds(
+            @Param("placeType") PlaceType placeType,
+            @Param("minLat") double minLat,
+            @Param("maxLat") double maxLat,
+            @Param("minLng") double minLng,
+            @Param("maxLng") double maxLng
+    );
 
-    @Query("SELECT p FROM Place p JOIN p.festivalAttribute f WHERE f.startDate <= :currentDate AND f.endDate >= :currentDate")
-    List<Place> findOngoingFestivals(@Param("currentDate") LocalDate currentDate);
+    @Query("SELECT new com.seohaeng.backend.domain.place.dto.PlaceMarkerDTO(p.id, p.name, p.latitude, p.longitude) " +
+            "FROM Place p JOIN p.festivalAttribute f " +
+            "WHERE f.startDate <= :currentDate AND f.endDate >= :currentDate " +
+            "AND p.latitude IS NOT NULL AND p.longitude IS NOT NULL " +
+            "AND p.latitude BETWEEN :minLat AND :maxLat " +
+            "AND p.longitude BETWEEN :minLng AND :maxLng")
+    List<PlaceMarkerDTO> findOngoingFestivalMarkerDTOsByBounds(
+            @Param("currentDate") LocalDate currentDate,
+            @Param("minLat") double minLat,
+            @Param("maxLat") double maxLat,
+            @Param("minLng") double minLng,
+            @Param("maxLng") double maxLng
+    );
 
 }

--- a/src/main/java/com/seohaeng/backend/domain/place/service/TourismMarkerService.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/service/TourismMarkerService.java
@@ -3,8 +3,8 @@ package com.seohaeng.backend.domain.place.service;
 import com.seohaeng.backend.domain.place.dto.PlaceMarkerDTO;
 import com.seohaeng.backend.domain.place.entity.enums.PlaceType;
 import com.seohaeng.backend.domain.place.repository.PlaceRepository;
-import com.seohaeng.backend.domain.place.util.MarkerUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,36 +19,20 @@ public class TourismMarkerService {
     private final PlaceRepository placeRepository;
 
     public List<PlaceMarkerDTO> getTouristSpotMarkers(double minLat, double minLng, double maxLat, double maxLng) {
-        return MarkerUtils.filterAndConvert(
-                placeRepository.findByPlaceType(PlaceType.TOURIST_SPOT),
-                place -> place.getLatitude(),
-                place -> place.getLongitude(),
-                place -> new PlaceMarkerDTO(place.getId(), place.getName(), place.getLatitude(), place.getLongitude()),
-                minLat, minLng, maxLat, maxLng,
-                5
+        return placeRepository.findMarkerDTOsByPlaceTypeAndBounds(
+                PlaceType.TOURIST_SPOT, minLat, maxLat, minLng, maxLng
         );
     }
 
     public List<PlaceMarkerDTO> getFestivalMarkers(double minLat, double minLng, double maxLat, double maxLng) {
-        return MarkerUtils.filterAndConvert(
-                placeRepository.findOngoingFestivals(LocalDate.now()),
-                place -> place.getLatitude(),
-                place -> place.getLongitude(),
-                place -> new PlaceMarkerDTO(place.getId(), place.getName(), place.getLatitude(), place.getLongitude()),
-                minLat, minLng, maxLat, maxLng,
-                5
+        return placeRepository.findOngoingFestivalMarkerDTOsByBounds(
+                LocalDate.now(), minLat, maxLat, minLng, maxLng
         );
     }
 
     public List<PlaceMarkerDTO> getRestaurantMarkers(double minLat, double minLng, double maxLat, double maxLng) {
-        return MarkerUtils.filterAndConvert(
-                placeRepository.findByPlaceType(PlaceType.RESTAURANT),
-                place -> place.getLatitude(),
-                place -> place.getLongitude(),
-                place -> new PlaceMarkerDTO(place.getId(), place.getName(), place.getLatitude(), place.getLongitude()),
-                minLat, minLng, maxLat, maxLng,
-                5
+        return placeRepository.findMarkerDTOsByPlaceTypeAndBounds(
+                PlaceType.RESTAURANT, minLat, maxLat, minLng, maxLng
         );
     }
-
 }


### PR DESCRIPTION
## 📌 작업 내용

TourismMarkerService의 마커 조회 로직에서 불필요한 엔티티 로딩과 인메모리 필터링으로 인해 메모리 사용량이 증가하고 조회 효율이 저하되는 문제가 있었습니다.

기존에는 `findByPlaceType()`으로 해당 타입의 Place 엔티티를 모두 조회한 뒤, Java 스트림에서 bbox(지도 뷰포트) 필터링을 수행하고 DTO로 변환하는 방식이었습니다. 이로 인해 실제로 필요한 마커 수가 적더라도 수백~수천 건의 Place 엔티티가 JVM 힙에 적재되는 비효율이 발생했습니다.

이를 개선하기 위해 JPQL Constructor Expression 기반 DTO 프로젝션을 적용하고, bbox 필터링 및 LIMIT 처리를 DB 레벨로 이전했습니다. 또한 엔티티 전체를 조회하는 대신 마커 표시에 필요한 컬럼(`id`, `name`, `latitude`, `longitude`)만 조회하도록 변경하여 Over-Fetching을 제거했습니다.

### 변경 사항

- PlaceRepository에 JPQL DTO 프로젝션 쿼리 추가
  - `findMarkerDTOsByPlaceTypeAndBounds()`
  - `findOngoingFestivalMarkerDTOsByBounds()`
- bbox 필터링을 Java 메모리 영역에서 DB 레벨로 이전
- 엔티티 조회 대신 DTO 직접 조회 적용
- TourismMarkerService의 `MarkerUtils.filterAndConvert()` 제거
- LIMIT 처리를 DB 레벨로 이전

### Before

1. Place 엔티티 전체 조회
2. Java 스트림으로 bbox 필터링
3. DTO 변환
4. 결과 반환

### After

1. JPQL DTO 프로젝션 조회
2. DB 레벨 bbox 필터링 및 LIMIT 적용
3. DTO 직접 반환

## ✨ 개선 효과

- 불필요한 엔티티 로딩 제거
- Over-Fetching 제거
- 인메모리 필터링 제거
- 객체 생성 비용 감소
- 메모리 사용량 감소
- 마커 조회 성능 향상

## 🧩 연관 이슈

> close #113