### PR TITLE
♻️[Refactor] ReadingSpot 마커 조회 성능 개선을 위한 복합 인덱스 추가

### DIFF
--- a/src/main/java/com/seohaeng/backend/domain/place/service/BookStoreAttributeService.java
+++ b/src/main/java/com/seohaeng/backend/domain/place/service/BookStoreAttributeService.java
@@ -4,7 +4,7 @@ import com.seohaeng.backend.domain.place.dto.PlaceMarkerDTO;
 import com.seohaeng.backend.domain.place.repository.attribute.BookStoreAttributeRepository;
 import com.seohaeng.backend.domain.readingSpot.repository.ReadingSpotRepository;
 import com.seohaeng.backend.domain.place.util.MarkerUtils;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,18 +59,7 @@ public class BookStoreAttributeService {
     }
 
     public List<PlaceMarkerDTO> getReadingSpotMarkers(double minLat, double minLng, double maxLat, double maxLng) {
-        return readingSpotRepository.findAllByOpenedTrue(Pageable.unpaged()).stream()
-                .filter(r -> r.getLatitude() != null && r.getLongitude() != null)
-                .filter(r -> r.getLatitude() >= minLat && r.getLatitude() <= maxLat
-                        && r.getLongitude() >= minLng && r.getLongitude() <= maxLng)
-                .map(r -> new PlaceMarkerDTO(
-                        r.getId(),
-                        r.getTitle(),
-                        r.getLatitude(),
-                        r.getLongitude()
-                ))
-                .limit(5)
-                .toList();
+        return readingSpotRepository.findMarkerDTOsByBounds(minLat, maxLat, minLng, maxLng, PageRequest.of(0, 5));
     }
 
 }

--- a/src/main/java/com/seohaeng/backend/domain/readingSpot/entity/ReadingSpot.java
+++ b/src/main/java/com/seohaeng/backend/domain/readingSpot/entity/ReadingSpot.java
@@ -15,6 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 @Builder
+@Table(indexes = @Index(name = "idx_reading_spot_lat_lng", columnList = "latitude, longitude"))
 public class ReadingSpot extends BaseEntity {
 
     @Id

--- a/src/main/java/com/seohaeng/backend/domain/readingSpot/repository/ReadingSpotRepository.java
+++ b/src/main/java/com/seohaeng/backend/domain/readingSpot/repository/ReadingSpotRepository.java
@@ -1,12 +1,16 @@
 package com.seohaeng.backend.domain.readingSpot.repository;
 
+import com.seohaeng.backend.domain.place.dto.PlaceMarkerDTO;
 import com.seohaeng.backend.domain.readingSpot.entity.ReadingSpot;
 import com.seohaeng.backend.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReadingSpotRepository extends JpaRepository<ReadingSpot, Long> {
@@ -15,6 +19,20 @@ public interface ReadingSpotRepository extends JpaRepository<ReadingSpot, Long> 
     Optional<ReadingSpot> findWithReadingSpotImagesById(Long id);
 
     Page<ReadingSpot> findAllByUser(User user, Pageable pageable);
-    
+
     Page<ReadingSpot> findAllByOpenedTrue(Pageable pageable);
+
+    @Query("SELECT new com.seohaeng.backend.domain.place.dto.PlaceMarkerDTO(r.id, r.title, r.latitude, r.longitude) " +
+           "FROM ReadingSpot r " +
+           "WHERE r.opened = true " +
+           "AND r.latitude IS NOT NULL AND r.longitude IS NOT NULL " +
+           "AND r.latitude BETWEEN :minLat AND :maxLat " +
+           "AND r.longitude BETWEEN :minLng AND :maxLng")
+    List<PlaceMarkerDTO> findMarkerDTOsByBounds(
+            @Param("minLat") double minLat,
+            @Param("maxLat") double maxLat,
+            @Param("minLng") double minLng,
+            @Param("maxLng") double maxLng,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
## 📌 작업 내용

`/api/v1/places/markers/readingspots` API의 공간책갈피 마커 조회 성능을 개선하였습니다.

### 문제 상황

기존 구현은 `opened = true`인 공간책갈피 데이터를 모두 조회한 후, 애플리케이션 메모리에서 위도·경도 범위(Bounding Box)를 필터링하는 구조였습니다.

```java
readingSpotRepository.findAllByOpenedTrue(Pageable.unpaged()).stream()
    .filter(r -> r.getLatitude() >= minLat && r.getLatitude() <= maxLat ...)
    .limit(5)
    .toList();
```

이 방식은 데이터가 증가할수록 전체 데이터를 계속 로드해야 하므로 조회 비용이 선형적으로 증가하는 문제가 있었습니다. 또한 마커 표시를 위해 필요한 소수의 데이터만 사용함에도 불구하고 불필요한 엔티티 로딩과 메모리 사용이 발생하였습니다.

### 개선 내용

#### 1. DTO Projection 및 DB 레벨 필터링 적용

- 위도·경도 범위 필터링 로직을 Java 메모리에서 DB로 이관
- JPQL `BETWEEN` 조건을 활용하여 Bounding Box 필터링 수행
- `SELECT new PlaceMarkerDTO(...)` DTO Projection 적용
- `PageRequest.of(0, 5)`를 통해 LIMIT을 DB 레벨에서 처리
- 필요한 컬럼만 조회하여 불필요한 엔티티 로딩 제거

#### 2. 복합 인덱스 적용

`ReadingSpot(latitude, longitude)` 복합 인덱스를 추가하였습니다.

```sql
CREATE INDEX idx_reading_spot_lat_lng
ON reading_spot(latitude, longitude);
```

적용 후 실행 계획 분석 결과:

- Full Table Scan 제거
- `latitude BETWEEN` 조건을 활용한 Index Range Scan 수행
- `longitude BETWEEN` 조건에 대해 ICP(Index Condition Pushdown) 적용
- 테이블 접근 전 인덱스 레벨에서 추가 필터링 수행

### 성능 개선 결과

30만 건의 테스트 데이터를 기준으로 측정한 결과:

| 항목 | 개선 전 | 개선 후 |
|------|---------|---------|
| 쿼리 실행 시간 | 0.219s | 0.016s |

- 약 **92.7% 응답 시간 감소**
- 약 **13.7배 성능 향상**

## ✨ 참고 사항


## 🧩 연관 이슈

> close #118 


<br>